### PR TITLE
LIBITD-1645. Added Dockerfile for generating production Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Environment file
+.env
+
+# Log files
+logs/*
+!logs/.keep
+
+# Working storage directory, except for storage/etc
+storage/*
+!storage/etc
+!storage/circrequests
+
+storage/circrequests/*
+!storage/circrequests/README.md
+
+# Test storage directory, except for storage/circrequests/README.md
+tests/storage/*
+!tests/storage/circrequests
+tests/storage/circrequests/*
+!tests/storage/circrequests/README.md
+
+
+# Python dependency files
+caia.egg-info
+__pycache__
+
+# PyCharm IDE
+.idea/
+
+# npm files/directories
+node_modules/
+package-lock.json
+
+# Mountebank logs
+mb*.log
+
+# mypy cache
+.mypy_cache/
+
+# py-cov files
+.coverage
+htmlcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Dockerfile for the generating caia application Docker image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/caia:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
+
+FROM python:3.8.2-slim
+
+RUN apt-get update && \
+    apt-get install -y build-essential && \
+    apt-get clean
+
+# Create a user for the app.
+RUN addgroup --gid 9999 app && \
+    adduser --uid 9999 --gid 9999 --disabled-password --gecos "Application" app && \
+    usermod -L app
+
+USER app
+
+# Make a subdirectory in the home directory for the application and make in the
+# work directory
+RUN mkdir /home/app/caia
+
+# Configure the main working directory. This is the base
+# directory used in any further RUN, COPY, and ENTRYPOINT
+# commands.
+WORKDIR /home/app/caia
+
+# Add /home/app/.local/bin where the Python dependencies will be installed
+# to the PATH
+ENV PATH=/home/app/.local/bin:$PATH
+
+# Copy the requirements.txt file holding the Python packages to install and
+# run "pip install". This is a separate step so the dependencies will be cached
+# unless changes to the file are made.
+COPY --chown=app:app requirements.txt /home/app/caia/
+
+RUN cd /home/app/caia && \
+    pip install -r requirements.txt && \
+    cd ..
+
+# Copy the main application
+ENV PYTHONUNBUFFERED=1
+COPY  --chown=app:app . /home/app/caia
+
+# Install the main application
+RUN cd /home/app/caia && \
+    pip install .

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ requests to CaiaSoft, using the CaiaSoft API "/circrequests" endpoint.
 
 See [docs/DevelopmentSetup.md](docs/DevelopmentSetup.md).
 
+## Docker Image
+
+This application provides a "Dockerfile" for generating a Docker image for use
+in production. The Dockerfile provides a sample build command.
+
+In order to generate "clean" Docker images, the Docker images should be built
+from a fresh clone of the GitHub repository.
+
+## Docker.ci and Jenkinsfile
+
+The "Dockerfile.ci" file is used to encapsulate the environment needed by the
+continuous integration (ci) server for building and testing the application.
+
+The "Jenkinsfile" provides the Jenkins pipeline steps for building and testing
+the application.
+
 ## License
 
 See the [LICENSE](LICENSE.md) file for license rights and limitations


### PR DESCRIPTION
Added Dockerfile for generating a "caia" Docker image suitable for
use on the production servers.

Added "caia/circrequests/steps/__init__.py", because it seemed to be
needed when running, as otherwise the "circrequests/steps" module could
not be found.

Updated README.md, and added a ".dockerignore" file.

https://issues.umd.edu/browse/LIBITD-1645