### PR TITLE
LIBITD-1660. Remove "stops" mapping from "circrequests"

### DIFF
--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -1,12 +1,4 @@
 ---
-# Mapping of Aleph library codes to CaiaSoft stop locations
-library_stops: {
-  # <Aleph library code>: <CaiaSoft stop location>
-  CPMCK: McKeldin,
-  CPSPE: Hornbake,
-  CPPAL: MSPAL
-}
-
 # circrequests-specific configuration
 circrequests: {
   # The field in the Aleph response that uniquely identifies a record.

--- a/tests/circrequests/steps/create_dest_request_test.py
+++ b/tests/circrequests/steps/create_dest_request_test.py
@@ -20,5 +20,5 @@ def test_create_dest_request():
     step_result = create_dest_request.execute()
     assert step_result.was_successful() is True
 
-    expected_request_body = '{"requests": [{"barcode": "31430023550355", "request_type": "PYR", "stop": "McKeldin"}]}'
+    expected_request_body = '{"requests": [{"barcode": "31430023550355", "request_type": "PYR", "stop": "CPMCK"}]}'
     assert expected_request_body == step_result.get_result()


### PR DESCRIPTION
Aleph will provide the CaiaSoft "stop" code in the "stop" field, so
there is no need to provide a mapping.

https://issues.umd.edu/browse/LIBITD-1660