### PR TITLE
LIBITD-1664. Handle "denied" circrequests items

### DIFF
--- a/caia/circrequests/circrequests_job_config.py
+++ b/caia/circrequests/circrequests_job_config.py
@@ -55,6 +55,6 @@ class CircrequestsJobConfig(JobConfig):
             denied_keys_filepath = self['denied_keys_filepath']
             if not os.path.exists(denied_keys_filepath):
                 logger.warning(f"denied_keys_filepath file at '{denied_keys_filepath} was not found. Creating default.")
-                denied_keys:List[str] = []
+                denied_keys: List[str] = []
                 with open(denied_keys_filepath, "w") as fp:
                     json.dump(denied_keys, fp)

--- a/caia/circrequests/circrequests_job_config.py
+++ b/caia/circrequests/circrequests_job_config.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict
+from typing import Dict, List
 import json
 
 from caia.core.job_config import JobConfig
@@ -55,6 +55,6 @@ class CircrequestsJobConfig(JobConfig):
             denied_keys_filepath = self['denied_keys_filepath']
             if not os.path.exists(denied_keys_filepath):
                 logger.warning(f"denied_keys_filepath file at '{denied_keys_filepath} was not found. Creating default.")
-                denied_keys = []
+                denied_keys:List[str] = []
                 with open(denied_keys_filepath, "w") as fp:
                     json.dump(denied_keys, fp)

--- a/caia/circrequests/circrequests_job_config.py
+++ b/caia/circrequests/circrequests_job_config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from typing import Dict
+import json
 
 from caia.core.job_config import JobConfig
 
@@ -48,3 +49,12 @@ class CircrequestsJobConfig(JobConfig):
 
         last_success_lookup = config['last_success_lookup']
         self["last_success_filepath"] = get_last_success_filepath(last_success_lookup)
+
+        # Generate an empty "denied_keys" file, if it does not exist
+        if self['denied_keys_filepath']:
+            denied_keys_filepath = self['denied_keys_filepath']
+            if not os.path.exists(denied_keys_filepath):
+                logger.warning(f"denied_keys_filepath file at '{denied_keys_filepath} was not found. Creating default.")
+                denied_keys = []
+                with open(denied_keys_filepath, "w") as fp:
+                    json.dump(denied_keys, fp)

--- a/caia/circrequests/diff.py
+++ b/caia/circrequests/diff.py
@@ -43,37 +43,38 @@ class DiffResult:
             f"modified_entries: {self.modified_entries}, deleted_entries: {self.deleted_entries}]"
 
 
-def diff(key_field: str, list1: List[Dict[str, str]], list2: List[Dict[str, str]]) -> DiffResult:
+def diff(key_field: str,
+         previous: List[Dict[str, str]], current: List[Dict[str, str]]) -> DiffResult:
     """
     Compares Dictionary entries in the lists based on the given key_field,
     returning a DiffResult of new/modified/deleted entries.
     """
-    list1_as_dict = {entry[key_field]: entry for entry in list1}
-    list2_as_dict = {entry[key_field]: entry for entry in list2}
-    list1_keys = list1_as_dict.keys()
-    list2_keys = list2_as_dict.keys()
+    previous_as_dict = {entry[key_field]: entry for entry in previous}
+    current_as_dict = {entry[key_field]: entry for entry in current}
+    previous_keys = previous_as_dict.keys()
+    current_keys = current_as_dict.keys()
 
-    # Keys in list2 only (new)
-    new_keys = list(set(list2_keys) - set(list1_keys))
+    # Keys in current only (new)
+    new_keys = list(set(current_keys) - set(previous_keys))
     new_entries = []
     for key in new_keys:
-        new_entries.append(list2_as_dict[key])
+        new_entries.append(current_as_dict[key])
 
-    # Keys in list1 only (deleted)
-    deleted_keys = list(set(list1_keys) - set(list2_keys))
+    # Keys in previous only (deleted)
+    deleted_keys = list(set(previous_keys) - set(current_keys))
     deleted_entries = []
     for key in deleted_keys:
-        deleted_entries.append(list1_as_dict[key])
+        deleted_entries.append(previous_as_dict[key])
 
     # Keys in both lists (modified?)
-    possibly_modified_keys = list(set(list1_keys) & set(list2_keys))
+    possibly_modified_keys = list(set(previous_keys) & set(current_keys))
     modified_entries = []
     for key in possibly_modified_keys:
-        list1_value = list1_as_dict[key]
-        list2_value = list2_as_dict[key]
+        list1_value = previous_as_dict[key]
+        list2_value = current_as_dict[key]
 
         if list1_value != list2_value:
-            modified_entries.append(list2_as_dict[key])
+            modified_entries.append(current_as_dict[key])
 
     diff_result = DiffResult(new_entries, modified_entries, deleted_entries)
     return diff_result

--- a/caia/circrequests/diff.py
+++ b/caia/circrequests/diff.py
@@ -44,7 +44,8 @@ class DiffResult:
 
 
 def diff(key_field: str,
-         previous: List[Dict[str, str]], current: List[Dict[str, str]]) -> DiffResult:
+         previous: List[Dict[str, str]], current: List[Dict[str, str]],
+         denied_keys: List[str]) -> DiffResult:
     """
     Compares Dictionary entries in the lists based on the given key_field,
     returning a DiffResult of new/modified/deleted entries.
@@ -69,12 +70,25 @@ def diff(key_field: str,
     # Keys in both lists (modified?)
     possibly_modified_keys = list(set(previous_keys) & set(current_keys))
     modified_entries = []
+    modified_keys = []
     for key in possibly_modified_keys:
         list1_value = previous_as_dict[key]
         list2_value = current_as_dict[key]
 
         if list1_value != list2_value:
             modified_entries.append(current_as_dict[key])
+            modified_keys.append(key)
+
+    # Handle denied keys
+    # Denied keys in present in current list
+    denied_keys_in_current_set = set(current_keys).intersection(set(denied_keys))
+    # Combine new and modified keys into a single set
+    new_or_modified_keys_set = set(new_keys) | set(modified_keys)
+    # Denied keys in current, and not already in "new or modified" set need to be added
+    denied_keys_to_add = denied_keys_in_current_set - new_or_modified_keys_set
+
+    for key in denied_keys_to_add:
+        new_entries.append(current_as_dict[key])
 
     diff_result = DiffResult(new_entries, modified_entries, deleted_entries)
     return diff_result

--- a/caia/circrequests/diff.py
+++ b/caia/circrequests/diff.py
@@ -80,7 +80,7 @@ def diff(key_field: str,
             modified_keys.append(key)
 
     # Handle denied keys
-    # Denied keys in present in current list
+    # Denied keys present in current list
     denied_keys_in_current_set = set(current_keys).intersection(set(denied_keys))
     # Combine new and modified keys into a single set
     new_or_modified_keys_set = set(new_keys) | set(modified_keys)

--- a/caia/circrequests/steps/diff_against_last_success.py
+++ b/caia/circrequests/steps/diff_against_last_success.py
@@ -43,10 +43,17 @@ class DiffAgainstLastSuccess(Step):
             source_response = json.load(fp)
             current = self.parse_source_response(source_response)
 
+        # Retrieve the list of denied keys
+        denied_keys_filepath = self.job_config['denied_keys_filepath']
+        with open(denied_keys_filepath) as fp:
+            denied_keys = json.load(fp)
+
+        if len(denied_keys):
+            logger.debug(f"{len(denied_keys)} found.")
+
         key_field = self.job_config.application_config['circrequests']['source_key_field']
 
         # Generate the diff result
-        denied_keys = []
         diff_result = diff(key_field, last_success, current, denied_keys)
 
         step_result = StepResult(True, diff_result)

--- a/caia/circrequests/steps/diff_against_last_success.py
+++ b/caia/circrequests/steps/diff_against_last_success.py
@@ -46,7 +46,8 @@ class DiffAgainstLastSuccess(Step):
         key_field = self.job_config.application_config['circrequests']['source_key_field']
 
         # Generate the diff result
-        diff_result = diff(key_field, last_success, current)
+        denied_keys = []
+        diff_result = diff(key_field, last_success, current, denied_keys)
 
         step_result = StepResult(True, diff_result)
         return step_result

--- a/caia/circrequests/steps/record_denied_keys.py
+++ b/caia/circrequests/steps/record_denied_keys.py
@@ -28,7 +28,7 @@ class RecordDeniedKeys(Step):
                 denied_keys.append(result['item'])
 
         if denied_keys:
-            logger.info(f"There were {len(denied_keys)} key(s):")
+            logger.info(f"Denied key(s):")
             logger.info(denied_keys)
 
         # Always write out denied keys, even if there are none

--- a/caia/circrequests/steps/record_denied_keys.py
+++ b/caia/circrequests/steps/record_denied_keys.py
@@ -1,0 +1,44 @@
+import json
+import logging
+from typing import List
+
+from caia.circrequests.circrequests_job_config import CircrequestsJobConfig
+from caia.core.step import Step, StepResult
+
+logger = logging.getLogger(__name__)
+
+
+class RecordDeniedKeys(Step):
+    """
+    Records the filepath of the last successful source response.
+    """
+    def __init__(self, job_config: CircrequestsJobConfig, dest_response_body: str):
+        self.job_config = job_config
+        self.dest_response_body = dest_response_body
+        self.errors: List[str] = []
+
+    def execute(self) -> StepResult:
+        dest_response = json.loads(self.dest_response_body)
+        results = dest_response['results']
+        denied_keys = []
+
+        for result in results:
+            denied = result['deny'] == "Y"
+            if denied:
+                denied_keys.append(result['item'])
+
+        if denied_keys:
+            logger.info(f"There were {len(denied_keys)} key(s):")
+            logger.info(denied_keys)
+
+        # Always write out denied keys, even if there are none
+        denied_keys_filepath = self.job_config['denied_keys_filepath']
+        with open(denied_keys_filepath, "w") as fp:
+            json.dump(denied_keys, fp)
+
+        step_result = StepResult(True, denied_keys)
+        return step_result
+
+    def __str__(self) -> str:
+        fullname = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return f"{fullname}@{id(self)}"

--- a/caia/circrequests/steps/record_denied_keys.py
+++ b/caia/circrequests/steps/record_denied_keys.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class RecordDeniedKeys(Step):
     """
-    Records the filepath of the last successful source response.
+    Records the list of denied keys (if any).
     """
     def __init__(self, job_config: CircrequestsJobConfig, dest_response_body: str):
         self.job_config = job_config

--- a/caia/commands/circrequests.py
+++ b/caia/commands/circrequests.py
@@ -39,7 +39,8 @@ def create_job_configuration(start_time: str) -> CircrequestsJobConfig:
         'dest_url': os.getenv("CIRCREQUESTS_DEST_URL", default=""),
         'caiasoft_api_key': os.getenv('CAIASOFT_API_KEY', default=""),
         'storage_dir': os.getenv('CIRCREQUESTS_STORAGE_DIR', default=""),
-        'last_success_lookup': os.getenv('CIRCREQUESTS_LAST_SUCCESS_LOOKUP', default="")
+        'last_success_lookup': os.getenv('CIRCREQUESTS_LAST_SUCCESS_LOOKUP', default=""),
+        'denied_keys_filepath': os.getenv('CIRCREQUESTS_DENIED_KEYS', default="")
     }
 
     job_id_prefix = "caia.circrequests"

--- a/docs/adr/0006-aleph-interaction-assumptions-for-circrequests.md
+++ b/docs/adr/0006-aleph-interaction-assumptions-for-circrequests.md
@@ -1,0 +1,18 @@
+# 0006 - Aleph Interaction Assumptions for "circrequests"
+
+Date: June 15, 2020
+
+## Context
+
+For "circrequests", it is assumed that Aleph always provides a complete list
+of holds. A hold is considered valid as long as it is in the list provided by
+Aleph.
+
+## Consequences
+
+Because Aleph always provides a complete list of holds, it is up to this
+application to track which holds have been sent to CaiaSoft, as well
+as any holds that CaiaSoft has denied.
+
+A "denied" hold should be resubmitted (possibly using updated information from
+the Aleph response) as long as it still appears in the list from Aleph.

--- a/env_example
+++ b/env_example
@@ -18,6 +18,9 @@ CIRCREQUESTS_STORAGE_DIR=storage/circrequests/
 # File containing the fully-qualified filepath of the "last success"
 CIRCREQUESTS_LAST_SUCCESS_LOOKUP=storage/circrequests/circrequests_last_success.txt
 
+# File containing the fully-qualified filepath of the "denied keys"
+CIRCREQUESTS_DENIED_KEYS=storage/circrequests/circrequests_denied_keys.json
+
 #--- items properties
 # The URL to query for new/updated items
 ITEMS_SOURCE_URL=

--- a/tasks.py
+++ b/tasks.py
@@ -20,6 +20,14 @@ def reset(c):
     if last_successful_lookup and os.path.exists(last_successful_lookup) and os.path.isfile(last_successful_lookup):
         os.remove(last_successful_lookup)
 
+    denied_keys = os.getenv("CIRCREQUESTS_DENIED_KEYS") or ""
+    if not denied_keys:
+        print("Aborting. CIRCREQUESTS_DENIED_KEYS is not set.")
+        exit(1)
+
+    if denied_keys and os.path.exists(denied_keys) and os.path.isfile(denied_keys):
+        os.remove(denied_keys)
+
 
 @task(reset)
 def clean(c):

--- a/tests/circrequests/circrequests_job_config_test.py
+++ b/tests/circrequests/circrequests_job_config_test.py
@@ -1,0 +1,44 @@
+import json
+import os
+import tempfile
+from caia.circrequests.circrequests_job_config import CircrequestsJobConfig
+
+
+def test_denied_keys_file_is_created_if_it_does_not_exist():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage_dir = temp_dir
+        config = {
+            'storage_dir': storage_dir,
+            'last_success_lookup': 'etc/circrequests_FIRST.json',
+            'denied_keys_filepath': f"{storage_dir}denied_keys.json"
+        }
+        job_config = CircrequestsJobConfig(config)
+        denied_keys_filepath = job_config['denied_keys_filepath']
+        assert os.path.exists(denied_keys_filepath)
+        with open(denied_keys_filepath) as denied_keys_file:
+            denied_keys = json.load(denied_keys_file)
+            assert [] == denied_keys
+
+
+def test_denied_keys_file_is_not_created_if_already_exists():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage_dir = temp_dir
+        config = {
+            'storage_dir': storage_dir,
+            'last_success_lookup': 'etc/circrequests_FIRST.json',
+            'denied_keys_filepath': f"{storage_dir}/denied_keys.json"
+        }
+
+        expected_denied_keys = ['abc', 'def']
+        denied_keys_filepath = os.path.join(storage_dir, "denied_keys.json")
+
+        with open(denied_keys_filepath, "w") as denied_keys_file:
+            json.dump(expected_denied_keys, denied_keys_file)
+
+        job_config = CircrequestsJobConfig(config, "test", "test")
+        denied_keys_filepath = job_config['denied_keys_filepath']
+        print(f"denied_keys_filepath: {denied_keys_filepath}")
+        assert os.path.exists(denied_keys_filepath)
+        with open(denied_keys_filepath) as denied_keys_file:
+            denied_keys = json.load(denied_keys_file)
+            assert expected_denied_keys == denied_keys

--- a/tests/circrequests/diff_test.py
+++ b/tests/circrequests/diff_test.py
@@ -12,17 +12,18 @@ def test_diff():
     list1 = [entry1, entry2]
     list2 = [entry2, entry3]
     modified_list1 = [modified_entry1, entry2]
+    denied_keys = []
 
     key_field = "barcode"
 
     # list1 compared against empty list
-    diff_result_empty_to_list1 = diff(key_field, empty_list, list1)
+    diff_result_empty_to_list1 = diff(key_field, empty_list, list1, denied_keys)
     assert len(diff_result_empty_to_list1.new_entries) == 2
     assert len(diff_result_empty_to_list1.modified_entries) == 0
     assert len(diff_result_empty_to_list1.deleted_entries) == 0
 
     # list2 compared against list1
-    diff_result_list1_to_list2 = diff(key_field, list1, list2)
+    diff_result_list1_to_list2 = diff(key_field, list1, list2, denied_keys)
     assert len(diff_result_list1_to_list2.new_entries) == 1
     assert entry3 in diff_result_list1_to_list2.new_entries
     assert len(diff_result_list1_to_list2.modified_entries) == 0
@@ -30,11 +31,56 @@ def test_diff():
     assert entry1 in diff_result_list1_to_list2.deleted_entries
 
     # list1 compared against modified_list1
-    diff_result_list1_to_modified_list1 = diff(key_field, list1, modified_list1)
+    diff_result_list1_to_modified_list1 = diff(key_field, list1, modified_list1, denied_keys)
     assert len(diff_result_list1_to_modified_list1.new_entries) == 0
     assert len(diff_result_list1_to_modified_list1.modified_entries) == 1
     assert modified_entry1 in diff_result_list1_to_modified_list1.modified_entries
     assert len(diff_result_list1_to_modified_list1.deleted_entries) == 0
+
+
+def test_diff_with_denied_keys():
+    key_field = "barcode"
+
+    entry1 = {"barcode": "123", "item": "abc"}
+    entry2 = {"barcode": "234", "item": "bcd"}
+    entry3 = {"barcode": "345", "item": "cde"}
+
+    # Diff result not should include "denied" entry, as it is not in the
+    # current list
+    previous_list = [entry1, entry2]
+    current_list = [entry2, entry3]
+
+    denied_keys = [entry1["barcode"]]
+    diff_result = diff(key_field, previous_list, current_list, denied_keys)
+    assert len(diff_result.new_entries) == 1
+    assert len(diff_result.modified_entries) == 0
+    assert len(diff_result.deleted_entries) == 1
+    assert entry3 in diff_result.new_entries
+
+    # Diff result should include "denied" entry, as it is in the current list
+    previous_list = [entry1, entry2]
+    current_list = [entry2, entry3]
+    denied_keys = [entry2["barcode"]]
+
+    diff_result = diff(key_field, previous_list, current_list, denied_keys)
+    assert len(diff_result.new_entries) == 2
+    assert len(diff_result.modified_entries) == 0
+    assert len(diff_result.deleted_entries) == 1
+    assert entry2 in diff_result.new_entries
+    assert entry3 in diff_result.new_entries
+
+    # Diff result have the "denied" entry in the modified list
+    modified_entry2 = {"barcode": entry2['barcode'], "item": "ABC123"}
+    previous_list = [entry1, entry2]
+    current_list = [modified_entry2, entry3]
+
+    denied_keys = [modified_entry2["barcode"]]
+    diff_result = diff(key_field, previous_list, current_list, denied_keys)
+    assert len(diff_result.new_entries) == 1
+    assert len(diff_result.modified_entries) == 1
+    assert len(diff_result.deleted_entries) == 1
+    assert modified_entry2 in diff_result.modified_entries
+    assert entry3 in diff_result.new_entries
 
 
 def test_diff_result():

--- a/tests/circrequests/integration_test.py
+++ b/tests/circrequests/integration_test.py
@@ -8,11 +8,13 @@ from mbtest.matchers import had_request
 from caia.commands.circrequests import Command
 
 
-def setup_environment(imposter, temp_storage_dir, temp_success_filename):
+def setup_environment(imposter, temp_storage_dir, temp_success_filename,
+                      temp_denied_keys_filename="storage/circrequests/circrequests_denied_keys.json"):
     os.environ["CIRCREQUESTS_SOURCE_URL"] = f"{imposter.url}/src"
     os.environ["CIRCREQUESTS_DEST_URL"] = f"{imposter.url}/dest"
     os.environ["CIRCREQUESTS_STORAGE_DIR"] = temp_storage_dir
     os.environ["CIRCREQUESTS_LAST_SUCCESS_LOOKUP"] = temp_success_filename
+    os.environ["CIRCREQUESTS_DENIED_KEYS"] = temp_denied_keys_filename
     os.environ["CAIASOFT_API_KEY"] = 'TEST_KEY'
 
 
@@ -29,8 +31,8 @@ def test_successful_job(mock_server):
         Stub(Predicate(path="/dest", method="POST"), Response(body=valid_dest_response)),
         ])
 
-    # Create a temporary file to use as last success lookup
     try:
+        # Create a temporary file to use as last success lookup
         [temp_file_handle, temp_success_filename] = tempfile.mkstemp()
         with open(temp_success_filename, 'w') as f:
             f.write('etc/circrequests_FIRST.json')

--- a/tests/circrequests/integration_test.py
+++ b/tests/circrequests/integration_test.py
@@ -222,4 +222,3 @@ def test_dest_returns_denied_key(mock_server):
             denied_keys = json.load(file)
             assert denied_keys == ['31430023550355']
         os.remove(temp_denied_keys_filename)
-

--- a/tests/circrequests/integration_test.py
+++ b/tests/circrequests/integration_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 
@@ -172,3 +173,53 @@ def test_dest_returns_404_error(mock_server):
         # Clean up the temporary file
         os.close(temp_file_handle)
         os.remove(temp_success_filename)
+
+
+def test_dest_returns_denied_key(mock_server):
+    with open("tests/resources/circrequests/valid_src_response.json") as file:
+        valid_src_response = file.read()
+
+    with open("tests/resources/circrequests/valid_dest_response_denied_key.json") as file:
+        valid_dest_response_denied_key = file.read()
+
+    # Set up mock server with required behavior
+    imposter = Imposter([
+        Stub(Predicate(path="/src"), Response(body=valid_src_response)),
+        Stub(Predicate(path="/dest", method="POST"), Response(body=valid_dest_response_denied_key)),
+        ])
+
+    try:
+        # Create a temporary file to use as last success lookup
+        [temp_success_file_handle, temp_success_filename] = tempfile.mkstemp()
+        with open(temp_success_filename, 'w') as f:
+            f.write('etc/circrequests_FIRST.json')
+
+        # Create a temporary file to use as denied keys file
+        [temp_denied_keys_file_handle, temp_denied_keys_filename] = tempfile.mkstemp()
+        with open(temp_denied_keys_filename, 'w') as f:
+            f.write('[]')
+
+        with tempfile.TemporaryDirectory() as temp_storage_dir, mock_server(imposter) as server:
+            setup_environment(imposter, temp_storage_dir, temp_success_filename, temp_denied_keys_filename)
+
+            start_time = '20200521132905'
+            args = []
+
+            command = Command()
+            result = command(start_time, args)
+            assert result.was_successful() is True
+
+            assert_that(server, had_request().with_path("/src").and_method("GET"))
+            assert_that(server, had_request().with_path("/dest").and_method("POST"))
+    finally:
+        # Clean up the temporary files
+        os.close(temp_success_file_handle)
+        os.remove(temp_success_filename)
+
+        os.close(temp_denied_keys_file_handle)
+        # Verify that "denied keys" file contains denied entry
+        with open(temp_denied_keys_filename) as file:
+            denied_keys = json.load(file)
+            assert denied_keys == ['31430023550355']
+        os.remove(temp_denied_keys_filename)
+

--- a/tests/circrequests/steps/create_dest_request_test.py
+++ b/tests/circrequests/steps/create_dest_request_test.py
@@ -7,7 +7,8 @@ def test_create_dest_request():
     config = {
         'last_success_filepath': 'tests/resources/circrequests/valid_src_response_with_no_entries.json',
         'storage_dir': '/tmp',
-        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
     }
 
     job_config = CircrequestsJobConfig(config, 'test')

--- a/tests/circrequests/steps/diff_against_last_success_test.py
+++ b/tests/circrequests/steps/diff_against_last_success_test.py
@@ -6,7 +6,8 @@ def test_diff_against_last_success():
     config = {
         'last_success_filepath': 'tests/resources/circrequests/valid_src_response_with_no_entries.json',
         'storage_dir': '/tmp',
-        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
     }
 
     job_config = CircrequestsJobConfig(config, 'test')

--- a/tests/circrequests/steps/query_source_url_test.py
+++ b/tests/circrequests/steps/query_source_url_test.py
@@ -20,7 +20,8 @@ def test_valid_response_from_server(mock_server):
         config = {
             'source_url': f"{imposter.url}/holds",
             'storage_dir': '/tmp',
-            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+            'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
         }
         job_config = CircrequestsJobConfig(config, 'test')
 
@@ -42,7 +43,8 @@ def test_404_response_from_server(mock_server):
         config = {
             'source_url': f"{imposter.url}/holds",
             'storage_dir': '/tmp',
-            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+            'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
         }
         job_config = CircrequestsJobConfig(config, 'test')
 
@@ -60,7 +62,8 @@ def test_server_does_not_exist():
     config = {
         'source_url': "http://localhost:12345/URL_DOES_NOT_EXIST",
         'storage_dir': '/tmp',
-        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
     }
     job_config = CircrequestsJobConfig(config, 'test')
 

--- a/tests/circrequests/steps/record_denied_keys_test.py
+++ b/tests/circrequests/steps/record_denied_keys_test.py
@@ -1,0 +1,56 @@
+import json
+import os
+import tempfile
+
+from caia.circrequests.steps.record_denied_keys import RecordDeniedKeys
+
+
+def test_no_denied_keys(mock_server):
+    with open("tests/resources/circrequests/valid_dest_response.json") as file:
+        valid_dest_response = file.read()
+
+    try:
+        # Create a temporary file to use as denied keys file
+        [temp_denied_keys_file_handle, temp_denied_keys_filename] = tempfile.mkstemp()
+        config = {
+            'denied_keys_filepath': temp_denied_keys_filename
+        }
+
+        record_denied_keys = RecordDeniedKeys(config, valid_dest_response)
+        step_result = record_denied_keys.execute()
+        assert step_result.was_successful() is True
+    finally:
+        # Clean up the temporary file
+        os.close(temp_denied_keys_file_handle)
+
+        # Verify that "denied keys" file contains empty list
+        with open(temp_denied_keys_filename) as file:
+            denied_keys = json.load(file)
+            assert denied_keys == []
+        os.remove(temp_denied_keys_filename)
+
+
+def test_denied_keys(mock_server):
+    with open("tests/resources/circrequests/valid_dest_response_denied_key.json") as file:
+        valid_dest_response_denied_key = file.read()
+
+    try:
+        # Create a temporary file to use as denied keys file
+        [temp_denied_keys_file_handle, temp_denied_keys_filename] = tempfile.mkstemp()
+        config = {
+            'denied_keys_filepath': temp_denied_keys_filename
+        }
+
+        record_denied_keys = RecordDeniedKeys(config, valid_dest_response_denied_key)
+        step_result = record_denied_keys.execute()
+        assert step_result.was_successful() is True
+    finally:
+        # Clean up the temporary file
+        os.close(temp_denied_keys_file_handle)
+
+        # Verify that "denied keys" file contains a denied key
+        with open(temp_denied_keys_filename) as file:
+            denied_keys = json.load(file)
+            assert denied_keys == ['31430023550355']
+
+        os.remove(temp_denied_keys_filename)

--- a/tests/circrequests/steps/validate_job_preconditions_step_test.py
+++ b/tests/circrequests/steps/validate_job_preconditions_step_test.py
@@ -11,6 +11,7 @@ def test_validate_preconditions_returns_true_if_all_preconditions_are_met():
         'storage_dir': '/tmp/',
         'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
         'last_success_filepath': 'etc/circrequests_FIRST.json',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
     }
 
     job_config = CircrequestsJobConfig(config)
@@ -29,6 +30,7 @@ def test_validate_preconditions_returns_false_if_some_preconditions_are_not_met(
         'storage_dir': '/tmp/',
         'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
         'last_success_filepath': 'etc/circrequests_FIRST.json',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
     }
 
     job_config = CircrequestsJobConfig(config)

--- a/tests/resources/circrequests/valid_dest_response_denied_key.json
+++ b/tests/resources/circrequests/valid_dest_response_denied_key.json
@@ -1,0 +1,1 @@
+{"success":true,"error":"","request_count":"1","results":[{"item":"31430023550355","deny":"Y","istatus":"Invalid Stop Code"}]}


### PR DESCRIPTION
Modified the application to use a "denied keys" file (stored by default in "storage/circrequests/circrequests_denied_keys.json") which keeps track of the keys for any entries that CaiaSoft has denied. The "denied keys" file will contain the JSON for an empty array, if there are no denied keys/

Entries in the "denied keys" file are resubmitted to CaiaSoft as long as the key is contained in the list retrieved from Aleph.

https://issues.umd.edu/browse/LIBITD-1664