### PR TITLE
LIBITD-1666. Remove "stops" from "circrequests" submissions to CaiaSoft

### DIFF
--- a/caia/circrequests/steps/create_dest_request.py
+++ b/caia/circrequests/steps/create_dest_request.py
@@ -25,16 +25,11 @@ class CreateDestRequest(Step):
         Converts a single diff result entry into a format suitable for the
         CaiaSoft.
         """
-        aleph_library_location = diff_result_entry["stop"]
         patron_id = diff_result_entry["patron_id"]
 
-        # Aleph library location uses CaiaSoft "stop" codes, so simply
-        # pass Aleph location directly to CaiaSoft
-        caiasoft_library_stop = aleph_library_location
         post_entry = {
             "barcode": diff_result_entry[source_key_field],
             "request_type": "PYR",
-            "stop": caiasoft_library_stop,
             "patron_id": patron_id
         }
 

--- a/tests/circrequests/steps/create_dest_request_test.py
+++ b/tests/circrequests/steps/create_dest_request_test.py
@@ -22,6 +22,6 @@ def test_create_dest_request():
     assert step_result.was_successful() is True
 
     expected_request_body = \
-        '{"requests": [{"barcode": "31430023550355", "request_type": "PYR", "stop": "CPMCK", ' \
+        '{"requests": [{"barcode": "31430023550355", "request_type": "PYR", ' \
         '"patron_id": "000000224432"}]}'
     assert expected_request_body == step_result.get_result()


### PR DESCRIPTION
CaiaSoft has not been configured with all of the possible Aleph stops,
and only "McKeldin" currently exists, so use that for the CaiaSoft
"stop" code for all entries.

https://issues.umd.edu/browse/LIBITD-1666