### PR TITLE
LIBITD-1672. Updated "items" command to support "nextitem" continuation

### DIFF
--- a/caia/commands/items.py
+++ b/caia/commands/items.py
@@ -71,74 +71,86 @@ class Command(caia.core.command.Command):
             return CommandResult(step_result.was_successful(), step_result.get_errors())
 
         last_timestamp = step_result.get_result()
-
-        # Query source URL
         now = datetime.now()
         current_timestamp = now.strftime("%Y%m%d%H%M%S")
-        step_result = run_step(QuerySourceUrl(job_config, last_timestamp, current_timestamp))
-        write_to_file(job_config["source_response_body_filepath"], step_result.result)
-        if not step_result.was_successful():
-            return CommandResult(step_result.was_successful(), step_result.get_errors())
+        next_item = None
+        iteration_count = 1
 
-        source_response = step_result.get_result()
+        while True:
+            logger.info(f"---- Running iteration {iteration_count} ----")
+            job_config.set_iteration(iteration_count)
 
-        # Parse source response
-        step_result = run_step(ParseSourceResponse(source_response))
-        if not step_result.was_successful():
-            return CommandResult(step_result.was_successful(), step_result.get_errors())
-
-        source_items = step_result.get_result()
-        new_item_count = len(source_items.get_new_items())
-        updated_item_count = len(source_items.get_updated_items())
-
-        if new_item_count == 0:
-            logger.info("No new entries found, skipping CaiaSoft new items request.")
-        else:
-            logger.info(f"Sending {new_item_count} new item(s) to CaiaSoft.")
-            # Create new items POST body
-            step_result = run_step(CreateDestNewItemsRequest(source_items))
+            # Query source URL
+            step_result = run_step(QuerySourceUrl(job_config, last_timestamp, current_timestamp, next_item))
+            write_to_file(job_config["source_response_body_filepath"], step_result.result)
             if not step_result.was_successful():
                 return CommandResult(step_result.was_successful(), step_result.get_errors())
 
-            # Write new items request body to file
-            write_to_file(job_config['dest_new_items_request_body_filepath'], step_result.get_result())
+            source_response = step_result.get_result()
 
-            # Send POST new items data to destination
-            step_result = run_step(SendNewItemsToDest(job_config))
-
+            # Parse source response
+            step_result = run_step(ParseSourceResponse(source_response))
             if not step_result.was_successful():
                 return CommandResult(step_result.was_successful(), step_result.get_errors())
 
-            # Write new items dest response body to a file
-            write_to_file(job_config['dest_new_items_response_body_filepath'], step_result.get_result())
+            source_items = step_result.get_result()
+            new_item_count = len(source_items.get_new_items())
+            updated_item_count = len(source_items.get_updated_items())
+            next_item = source_items.get_next_item()
 
-            if not step_result.was_successful():
+            if new_item_count == 0:
+                logger.info("No new entries found, skipping CaiaSoft new items request.")
+            else:
+                logger.info(f"Sending {new_item_count} new item(s) to CaiaSoft.")
+                # Create new items POST body
+                step_result = run_step(CreateDestNewItemsRequest(source_items))
+                if not step_result.was_successful():
+                    return CommandResult(step_result.was_successful(), step_result.get_errors())
+
+                # Write new items request body to file
+                write_to_file(job_config['dest_new_items_request_body_filepath'], step_result.get_result())
+
+                # Send POST new items data to destination
+                step_result = run_step(SendNewItemsToDest(job_config))
+
+                if not step_result.was_successful():
+                    return CommandResult(step_result.was_successful(), step_result.get_errors())
+
+                # Write new items dest response body to a file
+                write_to_file(job_config['dest_new_items_response_body_filepath'], step_result.get_result())
+
+                if not step_result.was_successful():
+                    return CommandResult(step_result.was_successful(), step_result.get_errors())
+
+            if updated_item_count == 0:
+                logger.info("No updated entries found, skipping CaiaSoft updated items request.")
+            else:
+                logger.info(f"Sending {updated_item_count} updated item(s) to CaiaSoft.")
+                # Create updated items POST body
+                step_result = run_step(CreateDestUpdatedItemsRequest(source_items))
+                if not step_result.was_successful():
+                    return CommandResult(step_result.was_successful(), step_result.get_errors())
+
+                # Write updated items request body to file
+                write_to_file(job_config['dest_updated_items_request_body_filepath'], step_result.get_result())
+
+                # Send POST updated items data to destination
+                step_result = run_step(SendUpdatedItemsToDest(job_config))
+
+                if not step_result.was_successful():
+                    return CommandResult(step_result.was_successful(), step_result.get_errors())
+
+                # Write updated items dest response body to a file
+                write_to_file(job_config['dest_updated_items_response_body_filepath'], step_result.get_result())
+
+                if not step_result.was_successful():
+                    return CommandResult(step_result.was_successful(), step_result.get_errors())
+
+            # Record job as successful
+            step_result = run_step(UpdateLastSuccess(job_config))
+
+            if next_item is None:
                 return CommandResult(step_result.was_successful(), step_result.get_errors())
-
-        if updated_item_count == 0:
-            logger.info("No updated entries found, skipping CaiaSoft updated items request.")
-        else:
-            logger.info(f"Sending {updated_item_count} updated item(s) to CaiaSoft.")
-            # Create updated items POST body
-            step_result = run_step(CreateDestUpdatedItemsRequest(source_items))
-            if not step_result.was_successful():
-                return CommandResult(step_result.was_successful(), step_result.get_errors())
-
-            # Write updated items request body to file
-            write_to_file(job_config['dest_updated_items_request_body_filepath'], step_result.get_result())
-
-            # Send POST updated items data to destination
-            step_result = run_step(SendUpdatedItemsToDest(job_config))
-
-            if not step_result.was_successful():
-                return CommandResult(step_result.was_successful(), step_result.get_errors())
-
-            # Write updated items dest response body to a file
-            write_to_file(job_config['dest_updated_items_response_body_filepath'], step_result.get_result())
-
-            if not step_result.was_successful():
-                return CommandResult(step_result.was_successful(), step_result.get_errors())
-
-        # Record job as successful
-        step_result = run_step(UpdateLastSuccess(job_config))
-        return CommandResult(step_result.was_successful(), step_result.get_errors())
+            else:
+                logger.info(f"next_item is {next_item}. Commencing next iteration.")
+                iteration_count = iteration_count + 1

--- a/caia/commands/items.py
+++ b/caia/commands/items.py
@@ -152,5 +152,5 @@ class Command(caia.core.command.Command):
             if next_item is None:
                 return CommandResult(step_result.was_successful(), step_result.get_errors())
             else:
-                logger.info(f"next_item is {next_item}. Commencing next iteration.")
+                logger.info(f"next_item is '{next_item}'. Commencing next iteration.")
                 iteration_count = iteration_count + 1

--- a/caia/core/job_config.py
+++ b/caia/core/job_config.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from datetime import datetime
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 import yaml
 
@@ -28,14 +28,20 @@ class JobConfig(Dict[str, str]):
     def application_config(self) -> Any:
         return self.__application_config
 
-    def generate_filepath(self, base_dir: str, file_descriptor: str, file_extension: str) -> str:
+    def generate_filepath(self, base_dir: str, file_descriptor: str, file_extension: str,
+                          iteration_count: Optional[int] = None) -> str:
         """
         Returns a fully qualified filepath, based one this JobConfig, and
-        the given base directory, file descriptor, and extension
+        the given base directory, file descriptor, and extension, and
+        an optional iteration count
         """
         job_id = self['job_id']
 
-        base_filename = f"{job_id}.{file_descriptor}.{file_extension}"
+        iteration = ""
+        if iteration_count is not None:
+            iteration = f"-{iteration_count}"
+
+        base_filename = f"{job_id}{iteration}.{file_descriptor}.{file_extension}"
         return os.path.join(base_dir, base_filename)
 
     def __str__(self) -> str:

--- a/caia/items/items_job_config.py
+++ b/caia/items/items_job_config.py
@@ -20,26 +20,6 @@ class ItemsJobConfig(JobConfig):
     def __init__(self, config: Dict[str, str], job_id_prefix: str = '', timestamp: str = ""):
         super().__init__(config, job_id_prefix, timestamp)
 
-        storage_dir = self["storage_dir"]
-        source_response_body_filepath = self.generate_filepath(storage_dir, "source_response_body", "json")
-        self['source_response_body_filepath'] = source_response_body_filepath
-
-        dest_new_items_request_body_filepath = \
-            self.generate_filepath(storage_dir, "dest_new_items_request_body", "json")
-        self['dest_new_items_request_body_filepath'] = dest_new_items_request_body_filepath
-
-        dest_new_items_response_body_filepath = \
-            self.generate_filepath(storage_dir, "dest_new_items_response_body", "json")
-        self['dest_new_items_response_body_filepath'] = dest_new_items_response_body_filepath
-
-        dest_updated_items_request_body_filepath = \
-            self.generate_filepath(storage_dir, "dest_updated_items_request_body", "json")
-        self['dest_updated_items_request_body_filepath'] = dest_updated_items_request_body_filepath
-
-        dest_updated_items_response_body_filepath = \
-            self.generate_filepath(storage_dir, "dest_updated_items_response_body", "json")
-        self['dest_updated_items_response_body_filepath'] = dest_updated_items_response_body_filepath
-
         # Use "last_success_lookup" to populate the "last_success_filepath"
         # value, which is a JSON file containing the "last_update_time".
         # If the "last_success_lookup" file does not exist, create one,
@@ -54,3 +34,32 @@ class ItemsJobConfig(JobConfig):
 
         last_success_lookup = config['last_success_lookup']
         self["last_success_filepath"] = get_last_success_filepath(last_success_lookup)
+
+    def set_iteration(self, iteration: int) -> None:
+        """
+        Sets the iteration for the job, and updates the filepaths for job
+        artifacts.
+        """
+        self["iteration"] = str(iteration)
+
+        storage_dir = self["storage_dir"]
+
+        source_response_body_filepath = \
+            self.generate_filepath(storage_dir, "source_response_body", "json", iteration)
+        self['source_response_body_filepath'] = source_response_body_filepath
+
+        dest_new_items_request_body_filepath = \
+            self.generate_filepath(storage_dir, "dest_new_items_request_body", "json", iteration)
+        self['dest_new_items_request_body_filepath'] = dest_new_items_request_body_filepath
+
+        dest_new_items_response_body_filepath = \
+            self.generate_filepath(storage_dir, "dest_new_items_response_body", "json", iteration)
+        self['dest_new_items_response_body_filepath'] = dest_new_items_response_body_filepath
+
+        dest_updated_items_request_body_filepath = \
+            self.generate_filepath(storage_dir, "dest_updated_items_request_body", "json", iteration)
+        self['dest_updated_items_request_body_filepath'] = dest_updated_items_request_body_filepath
+
+        dest_updated_items_response_body_filepath = \
+            self.generate_filepath(storage_dir, "dest_updated_items_response_body", "json", iteration)
+        self['dest_updated_items_response_body_filepath'] = dest_updated_items_response_body_filepath

--- a/caia/items/source_items.py
+++ b/caia/items/source_items.py
@@ -1,16 +1,17 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 
 class SourceItems:
     """
     Encapsulates an "items" source response
     """
-    def __init__(self, new_items: List[Dict[str, str]], updated_items: List[Dict[str, str]]):
+    def __init__(self, new_items: List[Dict[str, str]], updated_items: List[Dict[str, str]], next_item: Optional[int]):
         """
         Creates a SourceItems object from the given source response.
         """
         self.new_items = new_items
         self.updated_items = updated_items
+        self.next_item = next_item
 
     def get_new_items(self) -> List[Dict[str, str]]:
         """
@@ -24,9 +25,17 @@ class SourceItems:
         """
         return self.updated_items
 
+    def get_next_item(self) -> Optional[int]:
+        """
+        Returns the index of the next item to request from the source, or None
+        if there are no more items
+        """
+        return self.next_item
+
     def __str__(self) -> str:
         """
         Returns a string representation of this object.
         """
         fullname = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return f"{fullname}@{id(self)}[new_items: {self.new_items}, updated_items: {self.updated_items}]"
+        return f"{fullname}@{id(self)}[new_items: {self.new_items}, updated_items: {self.updated_items}," \
+               f" next_item: {self.next_item}]"

--- a/caia/items/source_items.py
+++ b/caia/items/source_items.py
@@ -5,7 +5,7 @@ class SourceItems:
     """
     Encapsulates an "items" source response
     """
-    def __init__(self, new_items: List[Dict[str, str]], updated_items: List[Dict[str, str]], next_item: Optional[int]):
+    def __init__(self, new_items: List[Dict[str, str]], updated_items: List[Dict[str, str]], next_item: Optional[str]):
         """
         Creates a SourceItems object from the given source response.
         """
@@ -25,9 +25,9 @@ class SourceItems:
         """
         return self.updated_items
 
-    def get_next_item(self) -> Optional[int]:
+    def get_next_item(self) -> Optional[str]:
         """
-        Returns the index of the next item to request from the source, or None
+        Returns the key of the next item to request from the source, or None
         if there are no more items
         """
         return self.next_item

--- a/caia/items/steps/parse_source_response.py
+++ b/caia/items/steps/parse_source_response.py
@@ -18,8 +18,9 @@ class ParseSourceResponse(Step):
         obj = json.loads(self.source_response)
         new_items = obj['new']
         updated_items = obj['update']
+        next_item = obj.get('nextitem', None)
 
-        source_items = SourceItems(new_items, updated_items)
+        source_items = SourceItems(new_items, updated_items, next_item)
 
         step_result = StepResult(True, source_items)
         return step_result

--- a/caia/items/steps/query_source_url.py
+++ b/caia/items/steps/query_source_url.py
@@ -25,7 +25,7 @@ class QuerySourceUrl(Step):
         headers = {'Content-Type': 'application/json'}
         query_params = {"starttime": self.last_timestamp, "endtime": self.current_timestamp}
         if self.next_item is not None:
-            query_params['nextitem'] = self.next_item
+            query_params['nextitem'] = str(self.next_item)
 
         return http_get_request(source_url, headers, query_params)
 

--- a/caia/items/steps/query_source_url.py
+++ b/caia/items/steps/query_source_url.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from caia.core.http import http_get_request
 from caia.core.step import Step, StepResult
@@ -12,16 +12,20 @@ class QuerySourceUrl(Step):
     """
     Queries the source url and stores a successful response.
     """
-    def __init__(self, job_config: ItemsJobConfig, last_timestamp: str, current_timestamp: str):
+    def __init__(self, job_config: ItemsJobConfig, last_timestamp: str, current_timestamp: str,
+                 next_item: Optional[int]):
         self.job_config = job_config
         self.last_timestamp = last_timestamp
         self.current_timestamp = current_timestamp
         self.errors: List[str] = []
+        self.next_item = next_item
 
     def execute(self) -> StepResult:
         source_url = self.job_config['source_url']
         headers = {'Content-Type': 'application/json'}
         query_params = {"starttime": self.last_timestamp, "endtime": self.current_timestamp}
+        if self.next_item is not None:
+            query_params['nextitem'] = self.next_item
 
         return http_get_request(source_url, headers, query_params)
 

--- a/caia/items/steps/query_source_url.py
+++ b/caia/items/steps/query_source_url.py
@@ -13,7 +13,7 @@ class QuerySourceUrl(Step):
     Queries the source url and stores a successful response.
     """
     def __init__(self, job_config: ItemsJobConfig, last_timestamp: str, current_timestamp: str,
-                 next_item: Optional[int]):
+                 next_item: Optional[str]):
         self.job_config = job_config
         self.last_timestamp = last_timestamp
         self.current_timestamp = current_timestamp
@@ -25,7 +25,7 @@ class QuerySourceUrl(Step):
         headers = {'Content-Type': 'application/json'}
         query_params = {"starttime": self.last_timestamp, "endtime": self.current_timestamp}
         if self.next_item is not None:
-            query_params['nextitem'] = str(self.next_item)
+            query_params['nextitem'] = self.next_item
 
         return http_get_request(source_url, headers, query_params)
 

--- a/caia/items/steps/update_last_success.py
+++ b/caia/items/steps/update_last_success.py
@@ -19,7 +19,9 @@ class UpdateLastSuccess(Step):
         last_success_lookup = self.job_config['last_success_lookup']
 
         storage_dir = self.job_config['storage_dir']
-        last_success_filepath = self.job_config.generate_filepath(storage_dir, "source_response_body", "json")
+        last_success_filepath = \
+            self.job_config.generate_filepath(
+                storage_dir, "source_response_body", "json", int(self.job_config['iteration']))
         self.job_config['last_success_filepath'] = last_success_filepath
 
         with open(last_success_lookup, "w") as fp:

--- a/mountebank/README.md
+++ b/mountebank/README.md
@@ -41,3 +41,12 @@ A successful "items" session with two new items and two updated items.
 * ITEMS_SOURCE_URL: http://localhost:4545/items/source
 * ITEMS_DEST_NEW_URL: http://localhost:6565/items/dest/incoming
 * ITEMS_DEST_UPDATES_URL: http://localhost:6565/items/dest/updates
+
+### items_success_multiple_iterations.ejs
+
+A successful "items" session where a "nextitem" in the first response
+triggers a second iteration of queries to the source URL:
+
+* ITEMS_SOURCE_URL: http://localhost:4545/items/source
+* ITEMS_DEST_NEW_URL: http://localhost:6565/items/dest/incoming
+* ITEMS_DEST_UPDATES_URL: http://localhost:6565/items/dest/updates

--- a/mountebank/items_success_multiple_iterations.ejs
+++ b/mountebank/items_success_multiple_iterations.ejs
@@ -15,7 +15,7 @@
                 "path": "/items/source",
                 "method": "GET",
                 "headers": { "Content-Type": "application/json" },
-                "query": { "nextitem": "3" }
+                "query": { "nextitem": "003375441000010" }
               }
             }
           ]

--- a/mountebank/items_success_multiple_iterations.ejs
+++ b/mountebank/items_success_multiple_iterations.ejs
@@ -1,0 +1,81 @@
+{
+  "imposters": [
+    {
+      "port": 4545,
+      "protocol": "http",
+      "stubs": [
+        {
+          "responses": [
+            { "is": { "statusCode": 200,
+                      "body": "<%- stringify('responses/items_success_multiple_iterations_1_source_body.ejs') %>"
+            }}],
+          "predicates": [
+            {
+              "equals": {
+                "path": "/items/source",
+                "method": "GET",
+                "headers": { "Content-Type": "application/json" },
+                "query": { "nextitem": "3" }
+              }
+            }
+          ]
+        },
+        {
+          "responses": [
+            { "is": { "statusCode": 200,
+                      "body": "<%- stringify('responses/items_success_multiple_iterations_0_source_body.ejs') %>"
+            }}],
+          "predicates": [
+            {
+              "equals": {
+                "path": "/items/source",
+                "method": "GET",
+                "headers": { "Content-Type": "application/json" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "port": 6565,
+      "protocol": "http",
+      "stubs": [
+        {
+          "responses": [
+            { "is": { "statusCode": 200,
+                      "body": "<%- stringify('responses/items_success_dest_incoming_body.ejs') %>"
+                    }
+            }
+          ],
+          "predicates": [
+              {
+                "equals": {
+                  "path": "/items/dest/incoming",
+                  "method": "POST",
+                  "headers": { "Content-Type": "application/json" }
+                }
+              }
+          ]
+        },
+        {
+          "responses": [
+            { "is": { "statusCode": 200,
+                      "body": "<%- stringify('responses/items_success_dest_updates_body.ejs') %>"
+                    }
+            }
+          ],
+          "predicates": [
+            {
+              "equals": {
+                "path": "/items/dest/updates",
+                "method": "POST",
+                "headers": { "Content-Type": "application/json" }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/mountebank/responses/items_success_multiple_iterations_0_source_body.ejs
+++ b/mountebank/responses/items_success_multiple_iterations_0_source_body.ejs
@@ -1,0 +1,13 @@
+{
+"starttime":"20200601",
+"endtime":"20200603",
+"nextitem": 3,
+"new":[
+  {"barcode": "31430051000001", "title": "New Item 1", "flag": null},
+  {"barcode": "31430052000002", "title": "New Item 2", "flag": null}
+],
+"update":[
+  {"barcode": "31430051999991", "title": "Updated Item 1", "flag": null},
+  {"barcode": "31430051999992", "title": "Updated Item 2", "flag": null}
+]
+}

--- a/mountebank/responses/items_success_multiple_iterations_0_source_body.ejs
+++ b/mountebank/responses/items_success_multiple_iterations_0_source_body.ejs
@@ -1,7 +1,7 @@
 {
 "starttime":"20200601",
 "endtime":"20200603",
-"nextitem": 3,
+"nextitem": "003375441000010",
 "new":[
   {"barcode": "31430051000001", "title": "New Item 1", "flag": null},
   {"barcode": "31430052000002", "title": "New Item 2", "flag": null}

--- a/mountebank/responses/items_success_multiple_iterations_1_source_body.ejs
+++ b/mountebank/responses/items_success_multiple_iterations_1_source_body.ejs
@@ -1,0 +1,12 @@
+{
+"starttime":"20200601",
+"endtime":"20200603",
+"new":[
+  {"barcode": "31430051000003", "title": "New Item 3", "flag": null},
+  {"barcode": "31430052000004", "title": "New Item 4", "flag": null}
+],
+"update":[
+  {"barcode": "31430051999993", "title": "Updated Item 3", "flag": null},
+  {"barcode": "31430051999994", "title": "Updated Item 4", "flag": null}
+]
+}

--- a/tests/core/job_config_test.py
+++ b/tests/core/job_config_test.py
@@ -60,6 +60,19 @@ def test_generate_filepath():
     assert filepath2 == f"storage/foo/{job_id}.abc.json"
 
 
+def test_generate_filepath_with_iteration_count():
+    config = {}
+
+    job_config = JobConfig(config, 'test')
+    job_id = job_config["job_id"]
+
+    filepath1 = job_config.generate_filepath("/tmp", "test_file", "txt", 1)
+    assert filepath1 == f"/tmp/{job_id}-1.test_file.txt"
+
+    filepath2 = job_config.generate_filepath("storage/foo", "abc", "json", 42)
+    assert filepath2 == f"storage/foo/{job_id}-42.abc.json"
+
+
 def test_job_to_string():
     config = {
         'caiasoft_api_key': 'SECRET_CAIASOFT_API_KEY',

--- a/tests/items/multiple_iterations_integration_test.py
+++ b/tests/items/multiple_iterations_integration_test.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+
+from hamcrest import assert_that, has_entries
+from mbtest.imposters import Imposter, Predicate, Response, Stub
+from mbtest.matchers import had_request
+
+from caia.commands.items import Command
+
+
+def setup_environment(imposter, temp_storage_dir, temp_success_filename):
+    os.environ["ITEMS_SOURCE_URL"] = f"{imposter.url}/src"
+    os.environ["ITEMS_DEST_NEW_URL"] = f"{imposter.url}/dest/new"
+    os.environ["ITEMS_DEST_UPDATES_URL"] = f"{imposter.url}/dest/updated"
+    os.environ["ITEMS_STORAGE_DIR"] = temp_storage_dir
+    os.environ["ITEMS_LAST_SUCCESS_LOOKUP"] = temp_success_filename
+    os.environ["CAIASOFT_API_KEY"] = 'TEST_KEY'
+
+
+def test_successful_job(mock_server):
+    with open("tests/resources/items/valid_src_iteration_0_response.json") as file:
+        valid_src_iteration_0_response = file.read()
+
+    with open("tests/resources/items/valid_src_iteration_1_response.json") as file:
+        valid_src_iteration_1_response = file.read()
+
+    with open("tests/resources/items/valid_dest_new_items_response.json") as file:
+        valid_dest_new_items_response = file.read()
+
+    with open("tests/resources/items/valid_dest_updated_items_response.json") as file:
+        valid_dest_updated_items_response = file.read()
+
+    # Set up mock server with required behavior
+    imposter = Imposter([
+        Stub(Predicate(path="/src", query={"nextitem": 3}), Response(body=valid_src_iteration_1_response)),
+        Stub(Predicate(path="/src",), Response(body=valid_src_iteration_0_response)),
+        Stub(Predicate(path="/dest/new", method="POST"), Response(body=valid_dest_new_items_response)),
+        Stub(Predicate(path="/dest/updated", method="POST"), Response(body=valid_dest_updated_items_response)),
+        ])
+
+    # Create a temporary file to use as last success lookup
+    try:
+        [temp_file_handle, temp_success_filename] = tempfile.mkstemp()
+        with open(temp_success_filename, 'w') as f:
+            f.write('etc/items_FIRST.json')
+
+        with tempfile.TemporaryDirectory() as temp_storage_dir, mock_server(imposter) as server:
+            setup_environment(imposter, temp_storage_dir, temp_success_filename)
+
+            start_time = '20200521132905'
+            args = []
+
+            command = Command()
+            result = command(start_time, args)
+            assert result.was_successful() is True
+
+            assert_that(server, had_request().with_path("/src").with_method("GET").with_query(
+                has_entries({'nextitem': '3'})).with_times(1))
+            assert_that(server, had_request().with_path("/src").and_method("GET").with_times(2))
+            assert_that(server, had_request().with_path("/dest/new").and_method("POST"))
+            assert_that(server, had_request().with_path("/dest/updated").and_method("POST"))
+    finally:
+        # Clean up the temporary file
+        os.close(temp_file_handle)
+        os.remove(temp_success_filename)
+
+

--- a/tests/items/multiple_iterations_integration_test.py
+++ b/tests/items/multiple_iterations_integration_test.py
@@ -32,7 +32,8 @@ def test_successful_job(mock_server):
 
     # Set up mock server with required behavior
     imposter = Imposter([
-        Stub(Predicate(path="/src", query={"nextitem": 3}), Response(body=valid_src_iteration_1_response)),
+        Stub(Predicate(path="/src", query={"nextitem": "003375441000010"}),
+             Response(body=valid_src_iteration_1_response)),
         Stub(Predicate(path="/src",), Response(body=valid_src_iteration_0_response)),
         Stub(Predicate(path="/dest/new", method="POST"), Response(body=valid_dest_new_items_response)),
         Stub(Predicate(path="/dest/updated", method="POST"), Response(body=valid_dest_updated_items_response)),
@@ -55,7 +56,7 @@ def test_successful_job(mock_server):
             assert result.was_successful() is True
 
             assert_that(server, had_request().with_path("/src").with_method("GET").with_query(
-                has_entries({'nextitem': '3'})).with_times(1))
+                has_entries({'nextitem': '003375441000010'})).with_times(1))
             assert_that(server, had_request().with_path("/src").and_method("GET").with_times(2))
             assert_that(server, had_request().with_path("/dest/new").and_method("POST"))
             assert_that(server, had_request().with_path("/dest/updated").and_method("POST"))

--- a/tests/items/multiple_iterations_integration_test.py
+++ b/tests/items/multiple_iterations_integration_test.py
@@ -63,5 +63,3 @@ def test_successful_job(mock_server):
         # Clean up the temporary file
         os.close(temp_file_handle)
         os.remove(temp_success_filename)
-
-

--- a/tests/items/steps/query_source_url_test.py
+++ b/tests/items/steps/query_source_url_test.py
@@ -33,7 +33,7 @@ def test_valid_response_from_server(mock_server):
         }
         job_config = ItemsJobConfig(config, 'test')
 
-        query_source_url = QuerySourceUrl(job_config, last_timestamp, current_timestamp)
+        query_source_url = QuerySourceUrl(job_config, last_timestamp, current_timestamp, None)
 
         step_result = query_source_url.execute()
 
@@ -58,7 +58,7 @@ def test_404_response_from_server(mock_server):
         last_timestamp = "20200601"
         current_timestamp = "20200603"
 
-        query_source_url = QuerySourceUrl(job_config, last_timestamp, current_timestamp)
+        query_source_url = QuerySourceUrl(job_config, last_timestamp, current_timestamp, None)
 
         step_result = query_source_url.execute()
 
@@ -79,7 +79,7 @@ def test_server_does_not_exist():
     last_timestamp = "20200601"
     current_timestamp = "20200603"
 
-    query_source_url = QuerySourceUrl(job_config, last_timestamp, current_timestamp)
+    query_source_url = QuerySourceUrl(job_config, last_timestamp, current_timestamp, None)
 
     with pytest.raises(requests.exceptions.ConnectionError):
         query_source_url.execute()

--- a/tests/resources/items/valid_src_iteration_0_response.json
+++ b/tests/resources/items/valid_src_iteration_0_response.json
@@ -1,0 +1,13 @@
+{
+"starttime":"20200601",
+"endtime":"20200603",
+"nextitem": 3,
+"new":[
+  {"barcode": "31430051000001", "title": "New Item 1", "flag": null},
+  {"barcode": "31430052000002", "title": "New Item 2", "flag": null}
+],
+"update":[
+  {"barcode": "31430051999991", "title": "Updated Item 1", "flag": null},
+  {"barcode": "31430051999992", "title": "Updated Item 2", "flag": null}
+]
+}

--- a/tests/resources/items/valid_src_iteration_0_response.json
+++ b/tests/resources/items/valid_src_iteration_0_response.json
@@ -1,7 +1,7 @@
 {
 "starttime":"20200601",
 "endtime":"20200603",
-"nextitem": 3,
+"nextitem": "003375441000010",
 "new":[
   {"barcode": "31430051000001", "title": "New Item 1", "flag": null},
   {"barcode": "31430052000002", "title": "New Item 2", "flag": null}

--- a/tests/resources/items/valid_src_iteration_1_response.json
+++ b/tests/resources/items/valid_src_iteration_1_response.json
@@ -1,0 +1,12 @@
+{
+"starttime":"20200601",
+"endtime":"20200603",
+"new":[
+  {"barcode": "31430051000003", "title": "New Item 3", "flag": null},
+  {"barcode": "31430052000004", "title": "New Item 4", "flag": null}
+],
+"update":[
+  {"barcode": "31430051999993", "title": "Updated Item 3", "flag": null},
+  {"barcode": "31430051999994", "title": "Updated Item 4", "flag": null}
+]
+}


### PR DESCRIPTION
Modified the "items" command to be capable of running one or more source/destination iterations, outputting distinct artifacts for each iteration.

In the first iteration, the "next_item" value is None, and the "next_item" is updated based on the "nextitem" parameter retrieved from Aleph. Iterations continue as long as a "nextitem" parameter is received from Aleph (or an error occurs).

https://issues.umd.edu/browse/LIBITD-1672