### PR TITLE
LIBITD-1673. Modify "items" to pass all fields received from Aleph

### DIFF
--- a/caia/items/steps/create_dest_request.py
+++ b/caia/items/steps/create_dest_request.py
@@ -10,52 +10,19 @@ logger = logging.getLogger(__name__)
 
 def parse_item(item_from_source: Dict[str, str], suppress_null_values: bool) -> Dict[str, str]:
     """
-    Converts source map into a destination map using the keys expected at the
-    destination.
+    Converts source map into a destination map, sending all fields in the source
+    to the destination.
 
     If "suppress_nulls" is True, any keys with null values will _not_ be
     sent in the destination request.
     """
-    source_to_dest_key_mapping = {
-        # Mapping of keys in source entries to the key in the dest
-        # Only keys included in this mapping will be sent to the destination
-        #
-        # Mapping is:
-        # <Aleph field>:<CaiaSoft field>
-        "barcode": "barcode",
-        "title": "title",
-        "author": "author",
-        "volume": "volume",
-        "call_number": "call_number",
-        "collection": "collection",
-        "material": "material",
-        "oclc": "oclc",
-        "issn": "issn",
-        "isbn": "isbn",
-        "edition": "edition",
-        "copy_number": "copy_number",
-        "pages": "pages",
-        "publisher": "publisher",
-        "pub_place": "pub_place",
-        "pub_year": "pub_year",
-        "physical_desc": "physical_desc",
-        "item_type": "item_type",
-        "bib_location": "bib_location",
-        "bib_item_status": "bib_item_status",
-        "bib_item_code": "bib_item_code",
-        "bib_level": "bib_level",
-        "bib_item_id": "bib_item_id",
-        "bib_record_nbr": "bib_record_nbr"
-    }
-
     item_map = {}
-    for source_key, dest_key in source_to_dest_key_mapping.items():
-        if source_key in item_from_source:
-            source_value = item_from_source[source_key]
-            if suppress_null_values and source_value is None:
-                continue
+    for source_key in item_from_source:
+        source_value = item_from_source[source_key]
+        if suppress_null_values and source_value is None:
+            continue
 
-            item_map[dest_key] = item_from_source[source_key]
+        item_map[source_key] = item_from_source[source_key]
 
     return item_map
 

--- a/tests/items/steps/create_dest_request_test.py
+++ b/tests/items/steps/create_dest_request_test.py
@@ -10,14 +10,14 @@ def test_parse_item():
     assert parsed_item["title"] == "Jane Eyre"
 
 
-def test_parse_item_only_includes_keys_in_mapping():
+def test_parse_item_send_all_keys_in_source_to_destination():
     source_item = {"barcode": "33433096993165", "title": "Jane Eyre", "foobar": "quuz"}
     parsed_item = parse_item(source_item, False)
 
-    assert 2 == len(parsed_item.keys())
+    assert 3 == len(parsed_item.keys())
     assert parsed_item["barcode"] == "33433096993165"
     assert parsed_item["title"] == "Jane Eyre"
-    assert "foobar" not in parsed_item
+    assert parsed_item["foobar"] == "quuz"
 
 
 def test_parse_item_suppresses_null_values_when_true():
@@ -51,7 +51,7 @@ def test_create_dest_new_items_request():
     step_result = create_dest_new_items_request.execute()
     request_body_str = step_result.get_result()
 
-    assert '{"incoming": [{"barcode": "33433096993165", "title": "Jane Eyre", "collection": "DEMO"}]}' ==\
+    assert '{"incoming": [{"barcode": "33433096993165", "collection": "DEMO", "title": "Jane Eyre"}]}' ==\
            request_body_str
 
 
@@ -68,4 +68,4 @@ def test_create_dest_updated_items_request():
     step_result = create_dest_updated_items_request.execute()
     request_body_str = step_result.get_result()
 
-    assert '{"items": [{"barcode": "31234000023075", "title": "Wuthering Heights", "call_number": "R34.5", "physical_desc": "317 pages"}]}' == request_body_str  # noqa
+    assert '{"items": [{"barcode": "31234000023075", "call_number": "R34.5", "physical_desc": "317 pages", "title": "Wuthering Heights"}]}' == request_body_str  # noqa


### PR DESCRIPTION
Modified the "create_dest_request" step to pass all fields from Aleph
unchanged to CaiaSoft. This is acceptable because our collaboration with
CaiaSoft may result in undocumented fields being allowed.

https://issues.umd.edu/browse/LIBITD-1673