### PR TITLE
LIBITD-1676. Modified end_time to be derived from source response

### DIFF
--- a/caia/commands/items.py
+++ b/caia/commands/items.py
@@ -71,8 +71,7 @@ class Command(caia.core.command.Command):
             return CommandResult(step_result.was_successful(), step_result.get_errors())
 
         last_timestamp = step_result.get_result()
-        now = datetime.now()
-        current_timestamp = now.strftime("%Y%m%d%H%M%S")
+        end_time = None
         next_item = None
         iteration_count = 1
 
@@ -81,7 +80,7 @@ class Command(caia.core.command.Command):
             job_config.set_iteration(iteration_count)
 
             # Query source URL
-            step_result = run_step(QuerySourceUrl(job_config, last_timestamp, current_timestamp, next_item))
+            step_result = run_step(QuerySourceUrl(job_config, last_timestamp, end_time, next_item))
             write_to_file(job_config["source_response_body_filepath"], step_result.result)
             if not step_result.was_successful():
                 return CommandResult(step_result.was_successful(), step_result.get_errors())
@@ -97,6 +96,7 @@ class Command(caia.core.command.Command):
             new_item_count = len(source_items.get_new_items())
             updated_item_count = len(source_items.get_updated_items())
             next_item = source_items.get_next_item()
+            end_time = source_items.get_end_time()
 
             if new_item_count == 0:
                 logger.info("No new entries found, skipping CaiaSoft new items request.")

--- a/caia/items/source_items.py
+++ b/caia/items/source_items.py
@@ -5,13 +5,16 @@ class SourceItems:
     """
     Encapsulates an "items" source response
     """
-    def __init__(self, new_items: List[Dict[str, str]], updated_items: List[Dict[str, str]], next_item: Optional[str]):
+    def __init__(self, new_items: List[Dict[str, str]],
+                 updated_items: List[Dict[str, str]], next_item: Optional[str],
+                 end_time: str):
         """
         Creates a SourceItems object from the given source response.
         """
         self.new_items = new_items
         self.updated_items = updated_items
         self.next_item = next_item
+        self.end_time = end_time
 
     def get_new_items(self) -> List[Dict[str, str]]:
         """
@@ -32,10 +35,16 @@ class SourceItems:
         """
         return self.next_item
 
+    def get_end_time(self) -> str:
+        """
+        Return the query end time reported by the source
+        """
+        return self.end_time
+
     def __str__(self) -> str:
         """
         Returns a string representation of this object.
         """
         fullname = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return f"{fullname}@{id(self)}[new_items: {self.new_items}, updated_items: {self.updated_items}," \
-               f" next_item: {self.next_item}]"
+               f" next_item: {self.next_item}, end_time {self.end_time}]"

--- a/caia/items/steps/parse_source_response.py
+++ b/caia/items/steps/parse_source_response.py
@@ -18,13 +18,14 @@ class ParseSourceResponse(Step):
         obj = json.loads(self.source_response)
         new_items = obj['new']
         updated_items = obj['update']
+        end_time = obj['endtime']
         next_item = obj.get('nextitem', None)
 
-        source_items = SourceItems(new_items, updated_items, next_item)
+        source_items = SourceItems(new_items, updated_items, next_item, end_time)
 
         step_result = StepResult(True, source_items)
         return step_result
 
     def __str__(self) -> str:
         fullname = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return f"{fullname}@{id(self)}"
+        return f"{fullname}@{id(self)} [source_response={self.source_response}]"

--- a/caia/items/steps/query_source_url.py
+++ b/caia/items/steps/query_source_url.py
@@ -11,19 +11,28 @@ logger = logging.getLogger(__name__)
 class QuerySourceUrl(Step):
     """
     Queries the source url and stores a successful response.
+
+    job_config: The ItemsJobConfig containing the current job information
+    start_time: The date/timestamp of the beginning of the query range
+    end_time: The date/timestamp of the end of the query range as returned
+              by the source. Should be may be None on the first iteration
+    next_item: The next_item to query for, as returned by the source when
+               multiple query iterations are needed.
     """
-    def __init__(self, job_config: ItemsJobConfig, last_timestamp: str, current_timestamp: str,
+    def __init__(self, job_config: ItemsJobConfig, start_time: str, end_time: Optional[str],
                  next_item: Optional[str]):
         self.job_config = job_config
-        self.last_timestamp = last_timestamp
-        self.current_timestamp = current_timestamp
+        self.start_time = start_time
+        self.end_time = end_time
         self.errors: List[str] = []
         self.next_item = next_item
 
     def execute(self) -> StepResult:
         source_url = self.job_config['source_url']
         headers = {'Content-Type': 'application/json'}
-        query_params = {"starttime": self.last_timestamp, "endtime": self.current_timestamp}
+        query_params = {"starttime": self.start_time}
+        if self.end_time is not None:
+            query_params['endtime'] = self.end_time
         if self.next_item is not None:
             query_params['nextitem'] = self.next_item
 
@@ -31,4 +40,5 @@ class QuerySourceUrl(Step):
 
     def __str__(self) -> str:
         fullname = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return f"{fullname}@{id(self)}"
+        return f"{fullname}@{id(self)} [start_time={self.start_time}, end_time={self.end_time}, " \
+               f"next_item={self.next_item}]"

--- a/docs/adr/0009-aleph-items-endpoint-behavior.md
+++ b/docs/adr/0009-aleph-items-endpoint-behavior.md
@@ -1,0 +1,54 @@
+# 0009 - Aleph "items" Endpoint Behavior
+
+Date: June 30, 2020
+
+## Context
+
+The Aleph endpoint used by the "items" command to query for new or updated
+accession items has the following behavior:
+
+1) When querying the endpoint for the first time, a "starttime" parameter that
+   is the "endtime" result from the last successful source response is provided.
+   In this context, "last successful" means that the new and updated entries
+   in the source response were successfully uploaded to CaiaSoft.
+   The "endtime" parameter must _not_ be provided on the first request.
+
+2) Every source response will include an "endtime" result that denotes the
+   end time of the query.
+     
+3) If there are a large number of results, Aleph may return a non-empty
+   "nextitem" entry in the response. This indicates that there are more entries
+   to retrieve, and additional source requests should be made. When making
+   requests for these additional entries:
+   
+   * The "starttime" parameter should be the same as the initial request
+   * The "endtime" parameter should be the same as the "endtime" entry in
+     the previous source response
+   * The "nextitem" entry from the previous source response should be provided.
+
+On the very first run of the "items" functionality, there is no previous
+source response to derive the "starttime" from. This is handled by providing
+a "default" source response. In the "default" source response, the "starttime"
+should be a simple datestamp (i.e., a date without a time), in order to avoid
+any timezone issues.
+ 
+Note that other than the first run, all the timestamps used for the "starttime"
+and "endtime" parameters are provided by Aleph. This avoids any issues regarding
+out-of-sync clocks between the servers and timezone issues, because only Aleph
+is providing the timestamps used for these parameters.
+
+## Consequences
+
+To support the "nextitem" continuation, the "items" steps run in multiple
+iterations, where the result from the last iteration is used as the input to
+the next iteration.
+
+Each iteration consists of:
+
+* Querying Aleph for the new/updated items
+* Sending new items to the CaiaSoft endpoint
+* Sending updated items to the CaiaSoft endpoint
+* Storing the "last successful" result to use in the next iteration/job
+
+The iterations operate within the context of a single job, and continue as long
+as the Aleph response contains a non-empty "nextitem" entry.


### PR DESCRIPTION
Instead of generating the the end_time using the current time, and
sending to the source, modified the steps so that:

1) For the first iteration, the end_time is not provided in the
request.

2) The end_time is retrieved from the source response, and provided in
the next iteration (if there is one).

The enables the source to (a) provide the end_time, and (b) removes
problems such as out-of-sync clocks on the middleware server and the
source, as well as any timezone issues.

https://issues.umd.edu/browse/LIBITD-1676