### PR TITLE
LIBITD-1677. Resubmit denied items after specified wait interval

### DIFF
--- a/caia/circrequests/circrequests_job_config.py
+++ b/caia/circrequests/circrequests_job_config.py
@@ -49,3 +49,12 @@ class CircrequestsJobConfig(JobConfig):
 
         last_success_lookup = config['last_success_lookup']
         self["last_success_filepath"] = get_last_success_filepath(last_success_lookup)
+
+        # Generate an empty "denied_keys" file, if it does not exist
+        if self['denied_keys_filepath']:
+            denied_keys_filepath = self['denied_keys_filepath']
+            if not os.path.exists(denied_keys_filepath):
+                logger.warning(f"denied_keys_filepath file at '{denied_keys_filepath} was not found. Creating default.")
+                denied_keys: Dict[str, str] = {}
+                with open(denied_keys_filepath, "w") as fp:
+                    json.dump(denied_keys, fp)

--- a/caia/circrequests/diff.py
+++ b/caia/circrequests/diff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # Needed for Python typing on "from_dict" static method
 
-from typing import Dict, List
+from typing import Dict, List, Set, Union, cast
+import datetime
 
 
 class DiffResult:
@@ -8,42 +9,65 @@ class DiffResult:
     Encapsulates the result of diffing two source responses
     """
     def __init__(self, new_entries: List[Dict[str, str]], modified_entries: List[Dict[str, str]],
-                 deleted_entries: List[Dict[str, str]]):
+                 deleted_entries: List[Dict[str, str]], denied_keys_to_persist: Dict[str, str]):
         self.new_entries = new_entries
         self.modified_entries = modified_entries
         self.deleted_entries = deleted_entries
+        self.denied_keys_to_persist = denied_keys_to_persist
 
-    def as_dict(self) -> Dict[str, List[Dict[str, str]]]:
+    def as_dict(self) -> Dict[str, Union[List[Dict[str, str]], Dict[str, str]]]:
         """
         Returns a Dictionary representation of this object.
         """
         result = {
             "new_entries": self.new_entries,
             "modified_entries": self.modified_entries,
-            "deleted_entries": self.deleted_entries
+            "deleted_entries": self.deleted_entries,
+            "denied_keys_to_persist": self.denied_keys_to_persist
         }
-        return result
+        return cast(Dict[str, Union[List[Dict[str, str]], Dict[str, str]]], result)
 
     @staticmethod
-    def from_dict(dictionary: Dict[str, List[Dict[str, str]]]) -> DiffResult:
+    def from_dict(dictionary: Dict[str, Union[List[Dict[str, str]], Dict[str, str]]]) -> DiffResult:
         """
         Returns a DiffResult from the given Dictionary, created the "as_dict"
         """
-        new_entries = dictionary["new_entries"]
-        modified_entries = dictionary["modified_entries"]
-        deleted_entries = dictionary["deleted_entries"]
-        return DiffResult(new_entries, modified_entries, deleted_entries)
+        new_entries = cast(List[Dict[str, str]], dictionary["new_entries"])
+        modified_entries = cast(List[Dict[str, str]], dictionary["modified_entries"])
+        deleted_entries = cast(List[Dict[str, str]], dictionary["deleted_entries"])
+        denied_keys_to_persist = cast(Dict[str, str], dictionary["denied_keys_to_persist"])
+        return DiffResult(new_entries, modified_entries, deleted_entries, denied_keys_to_persist)
 
     def __str__(self) -> str:
         """
         Returns a string representation of this object.
         """
         fullname = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return f"{fullname}@{id(self)}[new_entries: {self.new_entries},"\
-            f"modified_entries: {self.modified_entries}, deleted_entries: {self.deleted_entries}]"
+        return f"{fullname}@{id(self)}[new_entries: {self.new_entries}, "\
+            f"modified_entries: {self.modified_entries}, deleted_entries: {self.deleted_entries}, " \
+               f"denied_keys_to_persist: {self.denied_keys_to_persist}]"
 
 
-def diff(key_field: str, previous: List[Dict[str, str]], current: List[Dict[str, str]]) -> DiffResult:
+def denied_keys_to_resubmit(possible_keys: Set[str], denied_keys: Dict[str, str],
+                            current_time: datetime.datetime, wait_period_in_seconds: int) -> List[str]:
+    """
+    Return a List of keys from the given Dictionary that should be resubmitted
+    because the elapsed time since their last deny date is greater than the
+    given wait period.
+    """
+    result = []
+    for possible_key in possible_keys:
+        last_deny_date_str = denied_keys[possible_key]
+        last_deny_date = datetime.datetime.fromisoformat(last_deny_date_str)
+        time_diff = current_time - last_deny_date
+        if wait_period_in_seconds < time_diff.total_seconds():
+            result.append(possible_key)
+
+    return result
+
+
+def diff(key_field: str, previous: List[Dict[str, str]], current: List[Dict[str, str]],
+         denied_keys: Dict[str, str], current_time: datetime.datetime, denied_items_wait_interval: int) -> DiffResult:
     """
     Compares Dictionary entries in the lists based on the given key_field,
     returning a DiffResult of new/modified/deleted entries.
@@ -77,5 +101,31 @@ def diff(key_field: str, previous: List[Dict[str, str]], current: List[Dict[str,
             modified_entries.append(current_as_dict[key])
             modified_keys.append(key)
 
-    diff_result = DiffResult(new_entries, modified_entries, deleted_entries)
+    # Handle denied keys
+
+    # Denied keys present in current list
+    denied_keys_list = denied_keys.keys()
+    denied_keys_in_current_set = set(current_keys).intersection(set(denied_keys_list))
+
+    # Combine new and modified keys into a single set
+    new_or_modified_keys_set = set(new_keys) | set(modified_keys)
+
+    # Denied keys in current, and not already in "new or modified" set need to be added
+    possible_denied_keys_to_add = denied_keys_in_current_set - new_or_modified_keys_set
+
+    denied_keys_to_add = denied_keys_to_resubmit(possible_denied_keys_to_add, denied_keys,
+                                                 current_time, denied_items_wait_interval)
+
+    # Generate a list of denied keys that are still in the list, but will not
+    # be resubmitted. These keys (and their associated timestamp) will be
+    # persisted in the "denied_keys" file.
+    denied_keys_to_persist_list = possible_denied_keys_to_add.difference(denied_keys_to_add)
+    denied_keys_to_persist = {}
+    for key in denied_keys_to_persist_list:
+        denied_keys_to_persist[key] = denied_keys[key]
+
+    for key in denied_keys_to_add:
+        new_entries.append(current_as_dict[key])
+
+    diff_result = DiffResult(new_entries, modified_entries, deleted_entries, denied_keys_to_persist)
     return diff_result

--- a/caia/circrequests/steps/record_denied_keys.py
+++ b/caia/circrequests/steps/record_denied_keys.py
@@ -1,0 +1,54 @@
+import datetime
+import json
+import logging
+from typing import cast, Dict, List
+
+from caia.circrequests.circrequests_job_config import CircrequestsJobConfig
+from caia.core.step import Step, StepResult
+from caia.circrequests.diff import DiffResult
+
+logger = logging.getLogger(__name__)
+
+
+class RecordDeniedKeys(Step):
+    """
+    Records the list of denied keys (if any).
+    """
+    def __init__(self, job_config: CircrequestsJobConfig, dest_response_body: str,
+                 current_time: datetime.datetime, diff_result: DiffResult):
+        self.job_config = job_config
+        self.dest_response_body = dest_response_body
+        self.current_time = current_time
+        self.diff_result = diff_result
+        self.errors: List[str] = []
+
+    def execute(self) -> StepResult:
+        dest_response = json.loads(self.dest_response_body)
+        results = dest_response['results']
+        denied_keys = []
+
+        for result in results:
+            denied = result['deny'] == "Y"
+            if denied:
+                denied_keys.append(result['item'])
+
+        if denied_keys:
+            logger.info(f"Denied key(s):")
+            logger.info(denied_keys)
+
+        denied_keys_to_persist = cast(Dict[str, str], self.diff_result.as_dict()['denied_keys_to_persist'])
+        # Add any new denied keys to denied_keys_to_persist
+        for denied_key in denied_keys:
+            denied_keys_to_persist[denied_key] = self.current_time.isoformat()
+
+        # Always write out denied keys, even if there are none
+        denied_keys_filepath = self.job_config['denied_keys_filepath']
+        with open(denied_keys_filepath, "w") as fp:
+            json.dump(denied_keys_to_persist, fp)
+
+        step_result = StepResult(True, denied_keys_to_persist)
+        return step_result
+
+    def __str__(self) -> str:
+        fullname = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return f"{fullname}@{id(self)}"

--- a/caia/circrequests/steps/validate_job_preconditions.py
+++ b/caia/circrequests/steps/validate_job_preconditions.py
@@ -25,8 +25,11 @@ class ValidateJobPreconditions(Step):
         has_last_success_lookup = assertions.assert_file_exists(self.job_config, "last_success_lookup", self.errors)
         has_last_success_filepath = assertions.assert_file_exists(self.job_config, "last_success_filepath", self.errors)
 
+        has_denied_items_wait_interval = assertions.assert_is_non_negative_integer(
+            self.job_config, 'denied_items_wait_interval', self.errors)
+
         result = has_caiasoft_api_key and has_source_url and has_dest_url and has_storage_dir and \
-            has_last_success_lookup and has_last_success_filepath
+            has_last_success_lookup and has_last_success_filepath and has_denied_items_wait_interval
 
         step_result = StepResult(result, None, self.errors)
         return step_result

--- a/caia/commands/circrequests.py
+++ b/caia/commands/circrequests.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import json
 import logging
 import os
@@ -8,6 +9,7 @@ from caia.circrequests.circrequests_job_config import CircrequestsJobConfig
 from caia.circrequests.steps.create_dest_request import CreateDestRequest
 from caia.circrequests.steps.diff_against_last_success import DiffAgainstLastSuccess
 from caia.circrequests.steps.query_source_url import QuerySourceUrl
+from caia.circrequests.steps.record_denied_keys import RecordDeniedKeys
 from caia.circrequests.steps.send_to_dest import SendToDest
 from caia.circrequests.steps.update_last_success import UpdateLastSuccess
 from caia.circrequests.steps.validate_job_preconditions import ValidateJobPreconditions
@@ -39,7 +41,10 @@ def create_job_configuration(start_time: str) -> CircrequestsJobConfig:
         'dest_url': os.getenv("CIRCREQUESTS_DEST_URL", default=""),
         'caiasoft_api_key': os.getenv('CAIASOFT_API_KEY', default=""),
         'storage_dir': os.getenv('CIRCREQUESTS_STORAGE_DIR', default=""),
-        'last_success_lookup': os.getenv('CIRCREQUESTS_LAST_SUCCESS_LOOKUP', default="")
+        'last_success_lookup': os.getenv('CIRCREQUESTS_LAST_SUCCESS_LOOKUP', default=""),
+        'denied_keys_filepath': os.getenv('CIRCREQUESTS_DENIED_KEYS', default=""),
+        'denied_items_wait_interval':
+            os.getenv('CIRCREQUESTS_DENIED_ITEMS_WAIT_INTERVAL', default="604800")  # Default: 7 days
     }
 
     job_id_prefix = "caia.circrequests"
@@ -68,7 +73,8 @@ class Command(caia.core.command.Command):
             return CommandResult(step_result.was_successful(), step_result.get_errors())
 
         # Diff against last success
-        step_result = run_step(DiffAgainstLastSuccess(job_config))
+        current_time = datetime.datetime.strptime(start_time, '%Y%m%d%H%M%S')
+        step_result = run_step(DiffAgainstLastSuccess(job_config, current_time))
         if not step_result.was_successful():
             return CommandResult(step_result.was_successful(), step_result.get_errors())
 
@@ -96,7 +102,15 @@ class Command(caia.core.command.Command):
         step_result = run_step(SendToDest(job_config))
 
         # Write dest response body to a file
-        write_to_file(job_config['dest_response_body_filepath'], step_result.get_result())
+        dest_response_body = step_result.get_result()
+        write_to_file(job_config['dest_response_body_filepath'], dest_response_body)
+
+        if not step_result.was_successful():
+            return CommandResult(step_result.was_successful(), step_result.get_errors())
+
+        # Record denied keys (if any)
+        step_result = run_step(RecordDeniedKeys(job_config, dest_response_body, current_time,
+                                                diff_result))
 
         if not step_result.was_successful():
             return CommandResult(step_result.was_successful(), step_result.get_errors())

--- a/caia/core/assertions.py
+++ b/caia/core/assertions.py
@@ -52,6 +52,26 @@ def assert_nonempty_value(job_config: JobConfig, key: str, errors: List[str]) ->
     return result
 
 
+def assert_is_non_negative_integer(job_config: JobConfig, key: str, errors: List[str]) -> bool:
+    """
+    Returns True if the given key has a value that is non-empty string
+    representing a non-negative integer value, False otherwise.
+    """
+    if not assert_key_exists(job_config, key, errors):
+        return False
+
+    if not assert_value_not_none(job_config, key, errors):
+        return False
+
+    value = job_config[key]
+
+    result = value.isdigit()
+    if not result:
+        errors.append(f"'{key}' is not a non-negative integer.")
+
+    return result
+
+
 def assert_directory_exists(job_config: JobConfig, key: str, errors: List[str]) -> bool:
     """
     Returns True if the directory at the given key exists, False otherwise.

--- a/docs/adr/0006-aleph-interaction-assumptions-for-circrequests.md
+++ b/docs/adr/0006-aleph-interaction-assumptions-for-circrequests.md
@@ -2,15 +2,15 @@
 
 Date: June 15, 2020
 
+## Status
+
+Superseded by [0008-aleph-circrequests-denied-entries-handling.md][1]
+
 ## Context
 
 For "circrequests", it is assumed that Aleph always provides a complete list
 of holds. A hold is considered valid as long as it is in the list provided by
 Aleph.
-
-## Status
-
-Superseded by [0008-aleph-circrequests-denied-entries-handling.md][1]
 
 ## Consequences
 

--- a/docs/adr/0008-aleph-circrequests-denied-entries-handling.md
+++ b/docs/adr/0008-aleph-circrequests-denied-entries-handling.md
@@ -1,6 +1,10 @@
-# 0006 - Aleph "circrequests" Denied Entries Handling
+# 0008 - Aleph "circrequests" Denied Entries Handling
 
 Date: June 26, 2020
+
+## Status
+
+Superseded by [0010-aleph-circrequests-denied-entries-resubmission.md][2]
 
 ## Context
 
@@ -14,7 +18,7 @@ which holds have been sent to CaiaSoft, as well as any holds that CaiaSoft has
 denied, and resubmit them.
 
 When CaiaSoft denies an entry, information about the denied entry is presented
-in the CaiaSoft interfacce. Based on discussions with Hilary Thompson and
+in the CaiaSoft interface. Based on discussions with Hilary Thompson and
 Hans Breitenlohner, repeatedly submitting denied entries to CaiaSoft is not
 necessary, and merely adds extra work to clear on the CaiaSoft interface.
 
@@ -33,3 +37,4 @@ that interface.
 
 ----
 [1]: 0006-aleph-interaction-assumptions-for-circrequests.md
+[2]: 0010-aleph-circrequests-denied-entries-resubmission.md

--- a/docs/adr/0010-aleph-circrequests-denied-entries-resubmission.md
+++ b/docs/adr/0010-aleph-circrequests-denied-entries-resubmission.md
@@ -1,0 +1,36 @@
+# 0010 - Aleph "circrequests" Denied Entries Resubmission
+
+Date: July 1, 2020
+
+## Context
+
+In the original "caia" implementation, denied items were resubmitted as part
+of every submission to CaiaSoft, as long as the item was included in the list
+from Aleph.
+
+As denied items were typically being denied multiple times, this was causing
+redundant entries to appear in the CaiaSoft interface. So it was decided not
+resubmit denied items.
+
+After further consideration, there was a concern that never resubmitting
+denied items could result in patron requests getting lost. So it was decided
+that denied items should be resubmitted after a sufficient interval (such as
+7 days) as long as the denied item is still in the list provided by Aleph.
+
+## Decision
+
+Modify the application so that items denied by CaiaSoft are resubmitted if
+they are still being reported by Aleph after a configurable "wait interval".
+
+## Consequences
+
+This decision adds some complexity to the application, especially the
+"diff" functionality, which must take into account denied items and the
+wait interval.
+
+Also, this may affect upgrades and migrations to new servers, as the application
+now has additional "state" (the file containing the denied items and their
+timestamps) which may need to be migrated/replicated on the new server. 
+
+Hopefully, however, this functionality will prevent patron holds from being
+lost simply because of an initial denial from CaiaSoft.

--- a/env_example
+++ b/env_example
@@ -18,6 +18,13 @@ CIRCREQUESTS_STORAGE_DIR=storage/circrequests/
 # File containing the fully-qualified filepath of the "last success"
 CIRCREQUESTS_LAST_SUCCESS_LOOKUP=storage/circrequests/circrequests_last_success.txt
 
+# File containing the fully-qualified filepath of the "denied keys"
+CIRCREQUESTS_DENIED_KEYS=storage/circrequests/circrequests_denied_keys.json
+
+# The amount of time to wait (in seconds) before resubmitting a denied item
+# Default is 7 days
+CIRCREQUESTS_DENIED_ITEMS_WAIT_INTERVAL=604800
+
 #--- items properties
 # The URL to query for new/updated items
 ITEMS_SOURCE_URL=

--- a/mountebank/README.md
+++ b/mountebank/README.md
@@ -25,16 +25,24 @@ where <EJS_FILE> is the file containing the imposters to set up.
 The ".env" file of the "caia" application should then be configured with the
 URLs specified in the selected imposters configuration. 
 
-## Imposters configuration
+## Imposters configuration (EJS Files)
 
-### circrequests_success.ejs
+### mountebank/circrequests_success.ejs
 
 A successful "circrequests" session with one item.
 
 * CIRCREQUESTS_SOURCE_URL: http://localhost:4545/circrequests/source
 * CIRCREQUESTS_DEST_URL: http://localhost:6565/circrequests/dest
 
-### items_success.ejs
+### mountebank/circrequests_denied_keys.ejs
+
+A successful "circrequests" session with one denied item (barcode: 
+"denied_item") and one allowed item (barcode: "allowed_item").
+
+* CIRCREQUESTS_SOURCE_URL: http://localhost:4545/circrequests/source
+* CIRCREQUESTS_DEST_URL: http://localhost:6565/circrequests/dest
+
+### mountebank/items_success.ejs
 
 A successful "items" session with two new items and two updated items.
 
@@ -42,7 +50,7 @@ A successful "items" session with two new items and two updated items.
 * ITEMS_DEST_NEW_URL: http://localhost:6565/items/dest/incoming
 * ITEMS_DEST_UPDATES_URL: http://localhost:6565/items/dest/updates
 
-### items_success_multiple_iterations.ejs
+### mountebank/items_success_multiple_iterations.ejs
 
 A successful "items" session where a "nextitem" in the first response
 triggers a second iteration of queries to the source URL:

--- a/mountebank/circrequests_denied_keys.ejs
+++ b/mountebank/circrequests_denied_keys.ejs
@@ -1,0 +1,41 @@
+{
+  "imposters": [
+    {
+      "port": 4545,
+      "protocol": "http",
+      "stubs": [{
+        "responses": [
+          { "is": { "statusCode": 200,
+                    "body": "<%- stringify('responses/circrequests_denied_keys_source_body.ejs') %>"
+          }}],
+        "predicates": [
+            {
+              "equals": {
+                "path": "/circrequests/source",
+                "method": "GET",
+                "headers": { "Content-Type": "application/json" }
+              }
+            }]
+      }]
+    },
+
+    {
+      "port": 6565,
+      "protocol": "http",
+      "stubs": [{
+        "responses": [
+          { "is": { "statusCode": 200,
+                    "body": "<%- stringify('responses/circrequests_denied_keys_dest_body.ejs') %>"
+          }}],
+        "predicates": [
+            {
+              "equals": {
+                "path": "/circrequests/dest",
+                "method": "POST",
+                "headers": { "Content-Type": "application/json" }
+              }
+            }]
+      }]
+    }
+  ]
+}

--- a/mountebank/responses/circrequests_denied_keys_dest_body.ejs
+++ b/mountebank/responses/circrequests_denied_keys_dest_body.ejs
@@ -1,0 +1,17 @@
+{
+  "success":true,
+  "error": "",
+  "request_count": "2",
+  "results":[
+    {
+      "item": "denied_item",
+      "deny": "Y",
+      "istatus": "Item Cannot be Retrieved - Item is Currently Out of the Facility"
+    },
+    {
+      "item": "allowed_item",
+      "deny": "N",
+      "istatus": "Item Requested"
+    }
+  ]
+}

--- a/mountebank/responses/circrequests_denied_keys_source_body.ejs
+++ b/mountebank/responses/circrequests_denied_keys_source_body.ejs
@@ -1,0 +1,14 @@
+{
+  "holds": [
+    {
+      "barcode": "denied_item",
+      "stop": "CPMCK",
+      "patron_id": "000000224432"
+    },
+    {
+      "barcode": "allowed_item",
+      "stop": "CPMCK",
+      "patron_id": "000000224435"
+    }
+  ]
+}

--- a/tasks.py
+++ b/tasks.py
@@ -20,18 +20,24 @@ def clean_circrequests(c):
         print("Aborting. CIRCREQUESTS_STORAGE_DIR is not set.")
         exit(1)
 
+    files_to_skip = []
     # Figure out which JSON file (if any) is used by the last success lookup,
     # so we don't delete it.
-    item_last_success_lookup = os.getenv("CIRCREQUESTS_LAST_SUCCESS_LOOKUP")
+    circrequests_last_success_lookup = os.getenv("CIRCREQUESTS_LAST_SUCCESS_LOOKUP")
     last_success_filepath = None
-    if os.path.exists(item_last_success_lookup):
-        last_success_filepath = circrequests_get_last_success_filepath(item_last_success_lookup)
+    if os.path.exists(circrequests_last_success_lookup):
+        last_success_filepath = circrequests_get_last_success_filepath(circrequests_last_success_lookup)
+        files_to_skip.append(last_success_filepath)
+
+    denied_keys = os.getenv("CIRCREQUESTS_DENIED_KEYS")
+    if denied_keys and os.path.exists(denied_keys) and os.path.isfile(denied_keys):
+        files_to_skip.append(denied_keys)
 
     if circrequests_storage_dir and os.path.exists(circrequests_storage_dir):
         file_list = glob.glob(os.path.join(circrequests_storage_dir, '*.json'))
         for file_path in file_list:
-            # Skip the last_success_filepath
-            if last_success_filepath and file_path == last_success_filepath:
+            # Skip file if in files_to_skip
+            if file_path in files_to_skip:
                 continue
             try:
                 os.remove(file_path)
@@ -126,6 +132,14 @@ def reset_circrequests(c):
 
     if last_successful_lookup and os.path.exists(last_successful_lookup) and os.path.isfile(last_successful_lookup):
         os.remove(last_successful_lookup)
+
+    denied_keys = os.getenv("CIRCREQUESTS_DENIED_KEYS") or ""
+    if not denied_keys:
+        print("Aborting. CIRCREQUESTS_DENIED_KEYS is not set.")
+        exit(1)
+
+    if denied_keys and os.path.exists(denied_keys) and os.path.isfile(denied_keys):
+        os.remove(denied_keys)
 
 
 @task

--- a/tests/circrequests/assertions_test.py
+++ b/tests/circrequests/assertions_test.py
@@ -58,6 +58,42 @@ def test_assert_nonempty_value():
     assert "'nonexistent_key' is missing" in errors
 
 
+def test_assert_is_non_negative_integer():
+    config = {
+        # Allowed value
+        'key_with_integer_value': '1234',
+        'key_with_zero_value': '0',
+        # Disallowed values
+        'key_with_negative_integer_value': '-1234',
+        'key_with_none': None,
+        'key_with_empty_string': '',
+        'key_with_only_whitespace': '   \t  ',
+        'key_with_string_value': 'value',
+        'key_with_float_value': '1234.45',
+    }
+    job_config = JobConfig(config)
+
+    errors = []
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_integer_value', errors) is True
+    assert len(errors) == 0
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_zero_value', errors) is True
+    assert len(errors) == 0
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_negative_integer_value', errors) is False
+    assert "'key_with_negative_integer_value' is not a non-negative integer." in errors
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_float_value', errors) is False
+    assert "'key_with_float_value' is not a non-negative integer." in errors
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_string_value', errors) is False
+    assert "'key_with_string_value' is not a non-negative integer." in errors
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_none', errors) is False
+    assert "'key_with_none' has a value of None" in errors
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_empty_string', errors) is False
+    assert "'key_with_empty_string' is not a non-negative integer." in errors
+    assert assertions.assert_is_non_negative_integer(job_config, 'key_with_only_whitespace', errors) is False
+    assert "'key_with_only_whitespace' is not a non-negative integer." in errors
+    assert assertions.assert_is_non_negative_integer(job_config, 'nonexistent_key', errors) is False
+    assert "'nonexistent_key' is missing" in errors
+
+
 def test_assert_directory_exists():
     config = {
         'dir_exists': '/tmp/',

--- a/tests/circrequests/circrequests_job_config_test.py
+++ b/tests/circrequests/circrequests_job_config_test.py
@@ -1,0 +1,47 @@
+import json
+import os
+import tempfile
+from caia.circrequests.circrequests_job_config import CircrequestsJobConfig
+
+
+def test_denied_keys_file_is_created_if_it_does_not_exist():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage_dir = temp_dir
+        config = {
+            'storage_dir': storage_dir,
+            'last_success_lookup': 'etc/circrequests_FIRST.json',
+            'denied_keys_filepath': f"{storage_dir}denied_keys.json"
+        }
+        job_config = CircrequestsJobConfig(config)
+        denied_keys_filepath = job_config['denied_keys_filepath']
+        assert os.path.exists(denied_keys_filepath)
+        with open(denied_keys_filepath) as denied_keys_file:
+            denied_keys = json.load(denied_keys_file)
+            assert {} == denied_keys
+
+
+def test_denied_keys_file_is_not_created_if_already_exists():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage_dir = temp_dir
+        config = {
+            'storage_dir': storage_dir,
+            'last_success_lookup': 'etc/circrequests_FIRST.json',
+            'denied_keys_filepath': f"{storage_dir}/denied_keys.json"
+        }
+
+        expected_denied_keys = {
+            'june15': '2020-06-15T12:50:32.100736',
+            'june30': '2020-06-30T12:50:32.100736',
+        }
+        denied_keys_filepath = os.path.join(storage_dir, "denied_keys.json")
+
+        with open(denied_keys_filepath, "w") as denied_keys_file:
+            json.dump(expected_denied_keys, denied_keys_file)
+
+        job_config = CircrequestsJobConfig(config, "test", "test")
+        denied_keys_filepath = job_config['denied_keys_filepath']
+        print(f"denied_keys_filepath: {denied_keys_filepath}")
+        assert os.path.exists(denied_keys_filepath)
+        with open(denied_keys_filepath) as denied_keys_file:
+            denied_keys = json.load(denied_keys_file)
+            assert expected_denied_keys == denied_keys

--- a/tests/circrequests/diff_test.py
+++ b/tests/circrequests/diff_test.py
@@ -1,4 +1,5 @@
-from caia.circrequests.diff import diff, DiffResult
+import datetime
+from caia.circrequests.diff import denied_keys_to_resubmit, diff, DiffResult
 
 
 def test_diff():
@@ -12,17 +13,23 @@ def test_diff():
     list1 = [entry1, entry2]
     list2 = [entry2, entry3]
     modified_list1 = [modified_entry1, entry2]
+    denied_keys = {}
 
     key_field = "barcode"
 
+    current_time = datetime.datetime.now()
+    denied_items_wait_interval = 2 * 24 * 60 * 60  # 2 days
+
     # list1 compared against empty list
-    diff_result_empty_to_list1 = diff(key_field, empty_list, list1)
+    diff_result_empty_to_list1 = diff(key_field, empty_list, list1, denied_keys,
+                                      current_time, denied_items_wait_interval)
     assert len(diff_result_empty_to_list1.new_entries) == 2
     assert len(diff_result_empty_to_list1.modified_entries) == 0
     assert len(diff_result_empty_to_list1.deleted_entries) == 0
 
     # list2 compared against list1
-    diff_result_list1_to_list2 = diff(key_field, list1, list2)
+    diff_result_list1_to_list2 = diff(key_field, list1, list2, denied_keys,
+                                      current_time, denied_items_wait_interval)
     assert len(diff_result_list1_to_list2.new_entries) == 1
     assert entry3 in diff_result_list1_to_list2.new_entries
     assert len(diff_result_list1_to_list2.modified_entries) == 0
@@ -30,23 +37,148 @@ def test_diff():
     assert entry1 in diff_result_list1_to_list2.deleted_entries
 
     # list1 compared against modified_list1
-    diff_result_list1_to_modified_list1 = diff(key_field, list1, modified_list1)
+    diff_result_list1_to_modified_list1 = diff(key_field, list1, modified_list1, denied_keys,
+                                               current_time, denied_items_wait_interval)
     assert len(diff_result_list1_to_modified_list1.new_entries) == 0
     assert len(diff_result_list1_to_modified_list1.modified_entries) == 1
     assert modified_entry1 in diff_result_list1_to_modified_list1.modified_entries
     assert len(diff_result_list1_to_modified_list1.deleted_entries) == 0
 
 
+def test_denied_keys_to_resubmit():
+    june22 = datetime.datetime.fromisoformat('2020-06-22T11:36:33.032362')
+    denied_items_wait_interval = 3 * 24 * 60 * 60  # 3 days
+
+    denied_keys = {}
+    possible_keys = {}
+    denied_keys_to_add = denied_keys_to_resubmit(possible_keys, denied_keys, june22, denied_items_wait_interval)
+    assert len(denied_keys_to_add) == 0
+
+    denied_keys = {
+        'key_june15': '2020-06-15T11:36:33.032362',
+        'key_june20': '2020-06-20T11:36:33.032362',
+        'key_june22': '2020-06-22T11:36:33.032362',
+    }
+    possible_keys = set(denied_keys.keys())
+    denied_keys_to_add = denied_keys_to_resubmit(possible_keys, denied_keys, june22, denied_items_wait_interval)
+    assert len(denied_keys_to_add) == 1
+    assert 'key_june15' in denied_keys_to_add
+
+    june25_midnight = datetime.datetime.fromisoformat('2020-06-25T00:00:00.000000')
+    denied_keys_to_add = denied_keys_to_resubmit(possible_keys, denied_keys,
+                                                 june25_midnight, denied_items_wait_interval)
+    assert len(denied_keys_to_add) == 2
+    assert 'key_june15' in denied_keys_to_add
+    assert 'key_june20' in denied_keys_to_add
+
+    june25_noon = datetime.datetime.fromisoformat('2020-06-25T12:00:00.000000')
+    denied_keys_to_add = denied_keys_to_resubmit(possible_keys, denied_keys, june25_noon, denied_items_wait_interval)
+    assert len(denied_keys_to_add) == 3
+    assert 'key_june15' in denied_keys_to_add
+    assert 'key_june20' in denied_keys_to_add
+    assert 'key_june22' in denied_keys_to_add
+
+
+def test_diff_with_denied_keys():
+    key_field = "barcode"
+
+    entry1 = {"barcode": "entry1", "item": "abc"}
+    entry2 = {"barcode": "entry2", "item": "bcd"}
+    entry3 = {"barcode": "entry3", "item": "cde"}
+
+    # Diff result not should include "denied" entry, as it is not in the
+    # current list
+    previous_list = [entry1, entry2]
+    current_list = [entry2, entry3]
+
+    june22 = datetime.datetime.fromisoformat('2020-06-22T11:36:33.032362')
+    june23 = datetime.datetime.fromisoformat('2020-06-23T11:36:33.032362')
+    june30 = datetime.datetime.fromisoformat('2020-06-30T11:36:33.032362')
+
+    denied_keys = {
+        entry1["barcode"]: june22.isoformat()
+    }
+
+    denied_items_wait_interval = 2 * 24 * 60 * 60  # 2 days
+    diff_result = diff(key_field, previous_list, current_list, denied_keys,
+                       june30, denied_items_wait_interval)
+    assert len(diff_result.new_entries) == 1
+    assert len(diff_result.modified_entries) == 0
+    assert len(diff_result.deleted_entries) == 1
+    assert len(diff_result.denied_keys_to_persist) == 0
+    assert entry3 in diff_result.new_entries
+
+    # Diff result should include "denied" entry in the "new" entries,
+    # as it is in the current list, and the denied_items_wait_interval has
+    # expired
+    previous_list = [entry1, entry2]
+    current_list = [entry2, entry3]
+    denied_keys = {
+        entry2["barcode"]: june22.isoformat()
+    }
+
+    diff_result = diff(key_field, previous_list, current_list, denied_keys,
+                       june30, denied_items_wait_interval)
+    assert len(diff_result.new_entries) == 2
+    assert len(diff_result.modified_entries) == 0
+    assert len(diff_result.deleted_entries) == 1
+    assert len(diff_result.denied_keys_to_persist) == 0
+    assert entry2 in diff_result.new_entries
+    assert entry3 in diff_result.new_entries
+
+    # Diff result have the "denied" entry in the modified list
+    # as it is in the current list, and the denied_items_wait_interval has
+    # expired
+    modified_entry2 = {"barcode": entry2['barcode'], "item": "ABC123"}
+    previous_list = [entry1, entry2]
+    current_list = [modified_entry2, entry3]
+
+    denied_keys = {
+        modified_entry2["barcode"]: june22.isoformat()
+    }
+    diff_result = diff(key_field, previous_list, current_list, denied_keys,
+                       june30, denied_items_wait_interval)
+    assert len(diff_result.new_entries) == 1
+    assert len(diff_result.modified_entries) == 1
+    assert len(diff_result.deleted_entries) == 1
+    assert len(diff_result.denied_keys_to_persist) == 0
+    assert modified_entry2 in diff_result.modified_entries
+    assert entry3 in diff_result.new_entries
+
+    # Diff result will not have a "denied" entry as the
+    # denied_items_wait_interval has not expired
+    previous_list = [entry1, entry2]
+    current_list = [entry1, entry3]
+
+    denied_keys = {
+        entry1["barcode"]: june22.isoformat()
+    }
+
+    diff_result = diff(key_field, previous_list, current_list, denied_keys,
+                       june23, denied_items_wait_interval)
+    assert len(diff_result.new_entries) == 1
+    assert entry3 in diff_result.new_entries
+    assert len(diff_result.modified_entries) == 0
+    assert len(diff_result.deleted_entries) == 1
+    assert entry2 in diff_result.deleted_entries
+    assert len(diff_result.denied_keys_to_persist) == 1
+    assert entry1["barcode"] in diff_result.denied_keys_to_persist
+
+
 def test_diff_result():
     new_entries = [{"barcode": "345", "item": "cde"}]
-    modified_entries = [{"barcode": "123", "item": "ABC123"}]
-    deleted_entries = [{"barcode": "123", "item": "abc"}]
+    modified_entries = [{"barcode": "456", "item": "ABC123"}]
+    deleted_entries = [{"barcode": "789", "item": "abc"}]
+    denied_keys_to_persist = {
+        '987': '2020-06-22T11:36:33.032362',
+        '765': '2020-06-23T11:36:33.032362',
+    }
 
-    diff_result = DiffResult(new_entries, modified_entries, deleted_entries)
+    diff_result = DiffResult(new_entries, modified_entries, deleted_entries, denied_keys_to_persist)
 
     # as_dict method
     expected_dict = {"new_entries": new_entries, "modified_entries": modified_entries,
-                     "deleted_entries": deleted_entries}
+                     "deleted_entries": deleted_entries, "denied_keys_to_persist": denied_keys_to_persist}
     assert expected_dict == diff_result.as_dict()
 
     # from_dict method
@@ -54,9 +186,11 @@ def test_diff_result():
     assert diff_result2.new_entries == expected_dict["new_entries"]
     assert diff_result2.modified_entries == expected_dict["modified_entries"]
     assert diff_result2.deleted_entries == expected_dict["deleted_entries"]
+    assert diff_result2.denied_keys_to_persist == expected_dict["denied_keys_to_persist"]
 
     # str method
     str = diff_result.__str__()
     assert new_entries.__str__() in str
     assert modified_entries.__str__() in str
     assert deleted_entries.__str__() in str
+    assert denied_keys_to_persist.__str__() in str

--- a/tests/circrequests/steps/create_dest_request_test.py
+++ b/tests/circrequests/steps/create_dest_request_test.py
@@ -7,14 +7,15 @@ def test_create_dest_request():
     config = {
         'last_success_filepath': 'tests/resources/circrequests/valid_src_response_with_no_entries.json',
         'storage_dir': '/tmp',
-        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
     }
 
     job_config = CircrequestsJobConfig(config, 'test')
 
     new_entries = [{"barcode": "31430023550355", "stop": "CPMCK", "patron_id": "000000224432"}]
 
-    diff_result = DiffResult(new_entries, [], [])
+    diff_result = DiffResult(new_entries, [], [], [])
     create_dest_request = CreateDestRequest(job_config, diff_result)
 
     step_result = create_dest_request.execute()

--- a/tests/circrequests/steps/diff_against_last_success_test.py
+++ b/tests/circrequests/steps/diff_against_last_success_test.py
@@ -1,3 +1,4 @@
+import datetime
 from caia.circrequests.circrequests_job_config import CircrequestsJobConfig
 from caia.circrequests.steps.diff_against_last_success import DiffAgainstLastSuccess
 
@@ -6,14 +7,17 @@ def test_diff_against_last_success():
     config = {
         'last_success_filepath': 'tests/resources/circrequests/valid_src_response_with_no_entries.json',
         'storage_dir': '/tmp',
-        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json',
+        'denied_items_wait_interval': '604800'
     }
 
     job_config = CircrequestsJobConfig(config, 'test')
     # Override "source_response_body_filepath" in job config
     job_config['source_response_body_filepath'] = 'tests/resources/circrequests/valid_src_response.json'
 
-    diff_against_last_success = DiffAgainstLastSuccess(job_config)
+    current_time = datetime.datetime.now
+    diff_against_last_success = DiffAgainstLastSuccess(job_config, current_time)
 
     step_result = diff_against_last_success.execute()
     assert step_result.was_successful() is True

--- a/tests/circrequests/steps/query_source_url_test.py
+++ b/tests/circrequests/steps/query_source_url_test.py
@@ -20,7 +20,8 @@ def test_valid_response_from_server(mock_server):
         config = {
             'source_url': f"{imposter.url}/holds",
             'storage_dir': '/tmp',
-            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+            'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
         }
         job_config = CircrequestsJobConfig(config, 'test')
 
@@ -42,7 +43,8 @@ def test_404_response_from_server(mock_server):
         config = {
             'source_url': f"{imposter.url}/holds",
             'storage_dir': '/tmp',
-            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+            'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+            'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
         }
         job_config = CircrequestsJobConfig(config, 'test')
 
@@ -60,7 +62,8 @@ def test_server_does_not_exist():
     config = {
         'source_url': "http://localhost:12345/URL_DOES_NOT_EXIST",
         'storage_dir': '/tmp',
-        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt'
+        'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json'
     }
     job_config = CircrequestsJobConfig(config, 'test')
 

--- a/tests/circrequests/steps/record_denied_keys_test.py
+++ b/tests/circrequests/steps/record_denied_keys_test.py
@@ -1,0 +1,130 @@
+import datetime
+import json
+import os
+import tempfile
+
+from caia.circrequests.diff import DiffResult
+from caia.circrequests.steps.record_denied_keys import RecordDeniedKeys
+
+
+def test_no_denied_keys(mock_server):
+    with open("tests/resources/circrequests/valid_dest_response.json") as file:
+        valid_dest_response = file.read()
+
+    try:
+        # Create a temporary file to use as denied keys file
+        [temp_denied_keys_file_handle, temp_denied_keys_filename] = tempfile.mkstemp()
+        config = {
+            'denied_keys_filepath': temp_denied_keys_filename
+        }
+
+        current_time = datetime.datetime.now()
+        diff_result = DiffResult([], [], [], {})
+        record_denied_keys = RecordDeniedKeys(config, valid_dest_response,
+                                              current_time, diff_result)
+        step_result = record_denied_keys.execute()
+        assert step_result.was_successful() is True
+    finally:
+        # Clean up the temporary file
+        os.close(temp_denied_keys_file_handle)
+
+        # Verify that "denied keys" file contains empty dictionary
+        with open(temp_denied_keys_filename) as file:
+            denied_keys = json.load(file)
+            assert denied_keys == {}
+        os.remove(temp_denied_keys_filename)
+
+
+def test_denied_keys(mock_server):
+    with open("tests/resources/circrequests/valid_dest_response_denied_key.json") as file:
+        valid_dest_response_denied_key = file.read()
+
+    try:
+        # Create a temporary file to use as denied keys file
+        [temp_denied_keys_file_handle, temp_denied_keys_filename] = tempfile.mkstemp()
+        config = {
+            'denied_keys_filepath': temp_denied_keys_filename
+        }
+
+        current_time = datetime.datetime.now()
+        diff_result = DiffResult([], [], [], {})
+        record_denied_keys = RecordDeniedKeys(config, valid_dest_response_denied_key,
+                                              current_time, diff_result)
+        step_result = record_denied_keys.execute()
+        assert step_result.was_successful() is True
+    finally:
+        # Clean up the temporary file
+        os.close(temp_denied_keys_file_handle)
+
+        # Verify that "denied keys" file contains a denied key
+        with open(temp_denied_keys_filename) as file:
+            denied_keys = json.load(file)
+            assert denied_keys == {'31430023550355': current_time.isoformat()}
+
+        os.remove(temp_denied_keys_filename)
+
+
+def test_denied_keys_to_persist_no_new_denied_keys(mock_server):
+    with open("tests/resources/circrequests/valid_dest_response.json") as file:
+        valid_dest_response_denied_key = file.read()
+
+    try:
+        # Create a temporary file to use as denied keys file
+        [temp_denied_keys_file_handle, temp_denied_keys_filename] = tempfile.mkstemp()
+        config = {
+            'denied_keys_filepath': temp_denied_keys_filename
+        }
+
+        current_time = datetime.datetime.now()
+        june15 = '2020-06-15T11:36:33.032362'
+        persisted_denied_keys = {'persisted_key1': june15}
+        diff_result = DiffResult([], [], [], persisted_denied_keys)
+        record_denied_keys = RecordDeniedKeys(config, valid_dest_response_denied_key,
+                                              current_time, diff_result)
+        step_result = record_denied_keys.execute()
+        assert step_result.was_successful() is True
+    finally:
+        # Clean up the temporary file
+        os.close(temp_denied_keys_file_handle)
+
+        # Verify that "denied keys" file contains a denied key
+        with open(temp_denied_keys_filename) as file:
+            denied_keys = json.load(file)
+            assert denied_keys == {'persisted_key1': june15}
+
+        os.remove(temp_denied_keys_filename)
+
+
+def test_denied_keys_to_persist_and_a_new_denied_keys(mock_server):
+    with open("tests/resources/circrequests/valid_dest_response_denied_key.json") as file:
+        valid_dest_response_denied_key = file.read()
+
+    try:
+        # Create a temporary file to use as denied keys file
+        [temp_denied_keys_file_handle, temp_denied_keys_filename] = tempfile.mkstemp()
+        config = {
+            'denied_keys_filepath': temp_denied_keys_filename
+        }
+
+        current_time = datetime.datetime.now()
+        june15 = '2020-06-15T11:36:33.032362'
+        persisted_denied_keys = {'persisted_key1': june15}
+        diff_result = DiffResult([], [], [], persisted_denied_keys)
+        record_denied_keys = RecordDeniedKeys(config, valid_dest_response_denied_key,
+                                              current_time, diff_result)
+        step_result = record_denied_keys.execute()
+        assert step_result.was_successful() is True
+    finally:
+        # Clean up the temporary file
+        os.close(temp_denied_keys_file_handle)
+
+        # Verify that "denied keys" file contains a denied key
+        with open(temp_denied_keys_filename) as file:
+            denied_keys = json.load(file)
+            assert len(denied_keys) == 2
+            assert 'persisted_key1' in denied_keys
+            assert denied_keys['persisted_key1'] == june15
+            assert '31430023550355' in denied_keys
+            assert denied_keys['31430023550355'] == current_time.isoformat()
+
+        os.remove(temp_denied_keys_filename)

--- a/tests/circrequests/steps/validate_job_preconditions_step_test.py
+++ b/tests/circrequests/steps/validate_job_preconditions_step_test.py
@@ -10,7 +10,9 @@ def test_validate_preconditions_returns_true_if_all_preconditions_are_met():
         'log_dir': '/tmp/',
         'storage_dir': '/tmp/',
         'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
-        'last_success_filepath': 'etc/circrequests_FIRST.json'
+        'last_success_filepath': 'etc/circrequests_FIRST.json',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json',
+        'denied_items_wait_interval': '604800'
     }
 
     job_config = CircrequestsJobConfig(config)
@@ -28,7 +30,9 @@ def test_validate_preconditions_returns_false_if_some_preconditions_are_not_met(
         'log_dir': '/tmp/',
         'storage_dir': '/tmp/',
         'last_success_lookup': 'tests/storage/circrequests/circrequests_last_success.txt',
-        'last_success_filepath': 'etc/circrequests_FIRST.json'
+        'last_success_filepath': 'etc/circrequests_FIRST.json',
+        'denied_keys_filepath': 'tests/storage/circrequests/circrequests_denied_keys.json',
+        'denied_items_wait_interval': '604800'
     }
 
     job_config = CircrequestsJobConfig(config)

--- a/tests/resources/circrequests/valid_dest_response_denied_key.json
+++ b/tests/resources/circrequests/valid_dest_response_denied_key.json
@@ -1,0 +1,1 @@
+{"success":true,"error":"","request_count":"1","results":[{"item":"31430023550355","deny":"Y","istatus":"Invalid Stop Code"}]}


### PR DESCRIPTION
Modified "denied" keys to record the last time at which it was denied.

Modified the "diff" functionality to examine denied keys to determine
if any should be resubmitted.

Added "CIRCREQUESTS_DENIED_ITEMS_WAIT_INTERVAL" environment variable
to make the wait interval configurable.

Updated test cases to support changes.

https://issues.umd.edu/browse/LIBITD-1677