### PR TITLE
LIBITD-1681. Enabled null values to be replaced with sentinel value

### DIFF
--- a/tests/items/steps/create_dest_request_test.py
+++ b/tests/items/steps/create_dest_request_test.py
@@ -1,5 +1,6 @@
+import json
 from caia.items.steps.create_dest_request import CreateDestNewItemsRequest, CreateDestUpdatedItemsRequest
-from caia.items.steps.create_dest_request import parse_item
+from caia.items.steps.create_dest_request import parse_item, CAIASOFT_CLEAR_FIELD_SENTINEL_VALUE
 from caia.items.steps.parse_source_response import ParseSourceResponse
 
 
@@ -18,24 +19,6 @@ def test_parse_item_send_all_keys_in_source_to_destination():
     assert parsed_item["barcode"] == "33433096993165"
     assert parsed_item["title"] == "Jane Eyre"
     assert parsed_item["foobar"] == "quuz"
-
-
-def test_parse_item_suppresses_null_values_when_true():
-    source_item = {"barcode": "33433096993165", "title": None}
-    parsed_item = parse_item(source_item, True)
-
-    assert 1 == len(parsed_item.keys())
-    assert parsed_item["barcode"] == "33433096993165"
-    assert "title" not in parsed_item
-
-
-def test_parse_item_suppresses_null_values_when_false():
-    source_item = {"barcode": "33433096993165", "title": None}
-    parsed_item = parse_item(source_item, False)
-
-    assert 2 == len(parsed_item.keys())
-    assert parsed_item["barcode"] == "33433096993165"
-    assert parsed_item["title"] is None
 
 
 def test_create_dest_new_items_request():
@@ -69,3 +52,25 @@ def test_create_dest_updated_items_request():
     request_body_str = step_result.get_result()
 
     assert '{"items": [{"barcode": "31234000023075", "call_number": "R34.5", "physical_desc": "317 pages", "title": "Wuthering Heights"}]}' == request_body_str  # noqa
+
+
+def test_null_fields_preserved():
+    source_item_json = '{"barcode": "31234000023075", "call_number": null, "title": "Item with Null Fields", ' \
+                       '"physical_desc": null}'
+    source_item = json.loads(source_item_json)
+    parsed_item = parse_item(source_item, False)
+    assert parsed_item["barcode"] == "31234000023075"
+    assert parsed_item["call_number"] is None
+    assert parsed_item["title"] == "Item with Null Fields"
+    assert parsed_item["physical_desc"] is None
+
+
+def test_null_fields_convert_to_sentinel_value():
+    source_item_json = '{"barcode": "31234000023075", "call_number": null, "title": "Item with Null Fields", ' \
+                       '"physical_desc": null}'
+    source_item = json.loads(source_item_json)
+    parsed_item = parse_item(source_item, True)
+    assert parsed_item["barcode"] == "31234000023075"
+    assert parsed_item["call_number"] == CAIASOFT_CLEAR_FIELD_SENTINEL_VALUE
+    assert parsed_item["title"] == "Item with Null Fields"
+    assert parsed_item["physical_desc"] == CAIASOFT_CLEAR_FIELD_SENTINEL_VALUE


### PR DESCRIPTION
For "items" updates, Aleph will always send information about all the
fields for a record, using "null" for fields where there is no
information.

CaiaSoft does not automatically "clear" empty fields. So in order to
ensure that the data from Aleph and the data in CaiaSoft is in sync,
"null" values in "items" updates should be modified by the middleware
to the sentinel value "CLEARFIELD*". This will cause CaiaSoft to always
clear the field, regardless of its current value.

In the "parse_items" method of "caia/items/steps/create_dest_request.py",
replaced the unused "suppress_null_values" parameter with
"convert_null_values", and, when True, modified the method to replace
null values with the CaiaSoft sentinel value.

Updated the test cases.

https://issues.umd.edu/browse/LIBITD-1681