### PR TITLE
LIBITD-1682. Updated .dockeringore to include storage/items/README.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,12 +5,17 @@
 logs/*
 !logs/.keep
 
-# Working storage directory, except for storage/circrequests/README.md
+# Working storage directory, except for storage/circrequests/README.md and
+# storage/items/README.md
 storage/*
 !storage/circrequests
+!storage/items
 
 storage/circrequests/*
 !storage/circrequests/README.md
+
+storage/items/*
+!storage/items/README.md
 
 # Test storage directory, except for storage/circrequests/README.md
 tests/storage/*


### PR DESCRIPTION
The "storage/items/README.md" should be included in the Docker image.

https://issues.umd.edu/browse/LIBITD-1682