### PR TITLE
LIBITD-1739. Fixed success/warning logic for new items

### DIFF
--- a/caia/items/steps/send_new_items_to_dest.py
+++ b/caia/items/steps/send_new_items_to_dest.py
@@ -45,7 +45,7 @@ class SendNewItemsToDest(Step):
         rejects = response["rejects"]
 
         logger.info(f"New items request: Total: {incoming_count}, Rejected: {rejected_count}, reject: {rejects}")
-        if rejects == 0:
+        if rejected_count == 0:
             logger.info("SUCCESS - All new items were processed")
         else:
             logger.warning(f"WARNING - {rejected_count} new items(s) were rejected")


### PR DESCRIPTION
The "rejects" variable is an array, and so never matches an integer
zero. Modified to use the "rejected_counts" variable, which is an
integer.

https://issues.umd.edu/browse/LIBITD-1739